### PR TITLE
Shader auditing support

### DIFF
--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Unity.ProjectAuditor.Editor.Utils;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEditor.Rendering;
-using UnityEditorInternal;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace Unity.ProjectAuditor.Editor.Auditors
 {
@@ -19,6 +16,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         , IPreprocessBuildWithReport
 #endif
     {
+        const int k_ShaderVariantFirstId = 400000;
         static List<Tuple<string, IList<ShaderCompilerData>>> s_ShaderCompilerData;
 
         public IEnumerable<ProblemDescriptor> GetDescriptors()
@@ -40,13 +38,13 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
         public void Audit(Action<ProjectIssue> onIssueFound, Action onComplete, IProgressBar progressBar = null)
         {
-            var id = 400000;
+            var id = k_ShaderVariantFirstId;
             if (s_ShaderCompilerData == null)
             {
                 var descriptor = new ProblemDescriptor
                     (
                     id,
-                    "Analysis incomplete",
+                    "Shader analysis incomplete",
                     Area.BuildSize,
                     string.Empty,
                     string.Empty
@@ -54,7 +52,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
                 var message = "Build the project and run Project Auditor analysis";
 #if !UNITY_2018_1_OR_NEWER
-                message = "Shader Auditing requires Unity 2018";
+                message = "This feature requires Unity 2018";
 #endif
                 var issue = new ProjectIssue(descriptor, message, IssueCategory.Shaders);
                 issue.SetCustomProperties(new[] { string.Empty, string.Empty});
@@ -77,15 +75,14 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                         id++,
                         shader.name,
                         Area.BuildSize,
-                        "",
-                        ""
+                        string.Empty,
+                        string.Empty
                         );
 
                     foreach (var shaderCompilerData in shaderCompilerDataContainer.Item2)
                     {
                         var shaderKeywordSet = shaderCompilerData.shaderKeywordSet.GetShaderKeywords().ToArray();
                         var keywords = shaderKeywordSet.Select(keyword => keyword.GetKeywordName()).ToArray();
-//                        var names = shaderKeywordSet.Select(keyword => keyword.GetName());
                         var keywordString = String.Join(", ", keywords);
                         if (string.IsNullOrEmpty(keywordString))
                             keywordString = "<no keywords>";

--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Unity.ProjectAuditor.Editor.Utils;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.Rendering;
+using UnityEditorInternal;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Unity.ProjectAuditor.Editor.Auditors
+{
+    public class ShadersAuditor : IAuditor
+#if UNITY_2018_1_OR_NEWER
+        , IPreprocessShaders
+        , IPreprocessBuildWithReport
+#endif
+    {
+        static List<Tuple<string, IList<ShaderCompilerData>>> s_ShaderCompilerData;
+
+        public IEnumerable<ProblemDescriptor> GetDescriptors()
+        {
+            yield return null;
+        }
+
+        public void Initialize(ProjectAuditorConfig config)
+        {
+        }
+
+        public void Reload(string path)
+        {
+        }
+
+        public void RegisterDescriptor(ProblemDescriptor descriptor)
+        {
+        }
+
+        public void Audit(Action<ProjectIssue> onIssueFound, Action onComplete, IProgressBar progressBar = null)
+        {
+            var id = 400000;
+            if (s_ShaderCompilerData == null)
+            {
+                var descriptor = new ProblemDescriptor
+                    (
+                    id,
+                    "Analysis incomplete",
+                    Area.BuildSize,
+                    string.Empty,
+                    string.Empty
+                    );
+
+                var message = "Build the project and run Project Auditor analysis";
+#if !UNITY_2018_1_OR_NEWER
+                message = "Shader Auditing requires Unity 2018";
+#endif
+                var issue = new ProjectIssue(descriptor, message, IssueCategory.Shaders);
+                issue.SetCustomProperties(new[] { string.Empty, string.Empty});
+                onIssueFound(issue);
+                onComplete();
+                return;
+            }
+
+            var shaderGuids = AssetDatabase.FindAssets("t:shader");
+            foreach (var guid in shaderGuids)
+            {
+                var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                var shader = AssetDatabase.LoadMainAssetAtPath(assetPath) as Shader;
+
+                var shaderCompilerDataContainer = s_ShaderCompilerData.FirstOrDefault(entry => entry.Item1.Equals(shader.name));
+                if (shaderCompilerDataContainer != null)
+                {
+                    var descriptor = new ProblemDescriptor
+                        (
+                        id++,
+                        shader.name,
+                        Area.BuildSize,
+                        "",
+                        ""
+                        );
+
+                    foreach (var shaderCompilerData in shaderCompilerDataContainer.Item2)
+                    {
+                        var shaderKeywordSet = shaderCompilerData.shaderKeywordSet.GetShaderKeywords().ToArray();
+                        var keywords = shaderKeywordSet.Select(keyword => keyword.GetKeywordName()).ToArray();
+//                        var names = shaderKeywordSet.Select(keyword => keyword.GetName());
+                        var keywordString = String.Join(", ", keywords);
+                        if (string.IsNullOrEmpty(keywordString))
+                            keywordString = "<no keywords>";
+
+                        var issue = new ProjectIssue(descriptor, shader.name, IssueCategory.Shaders, new Location(assetPath));
+
+                        issue.SetCustomProperties(new[]
+                        {
+                            shaderCompilerData.shaderCompilerPlatform.ToString(),
+                            keywordString,
+                        });
+
+                        onIssueFound(issue);
+                    }
+                }
+            }
+
+            onComplete();
+        }
+
+#if UNITY_2018_1_OR_NEWER
+        public int callbackOrder { get { return 0; } }
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            s_ShaderCompilerData = new List<Tuple<string, IList<ShaderCompilerData>>>();
+        }
+
+        public void OnProcessShader(Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> data)
+        {
+            if (snippet.shaderType != ShaderType.Fragment)
+                return;
+
+            s_ShaderCompilerData.Add(new Tuple<string, IList<ShaderCompilerData>>(shader.name, data));
+        }
+
+#endif
+    }
+}

--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -7,6 +7,7 @@ using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEditor.Rendering;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Unity.ProjectAuditor.Editor.Auditors
 {
@@ -82,7 +83,8 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                     foreach (var shaderCompilerData in shaderCompilerDataContainer.Item2)
                     {
                         var shaderKeywordSet = shaderCompilerData.shaderKeywordSet.GetShaderKeywords().ToArray();
-                        var keywords = shaderKeywordSet.Select(keyword => keyword.GetKeywordName()).ToArray();
+
+                        var keywords = shaderKeywordSet.Select(keyword => ShaderKeyword.IsKeywordLocal(keyword) ?  ShaderKeyword.GetKeywordName(shader, keyword) : ShaderKeyword.GetGlobalKeywordName(keyword)).ToArray();
                         var keywordString = String.Join(", ", keywords);
                         if (string.IsNullOrEmpty(keywordString))
                             keywordString = "<no keywords>";

--- a/Editor/Auditors/ShadersAuditor.cs.meta
+++ b/Editor/Auditors/ShadersAuditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 73f4214d696240479bb86000dc910957
+timeCreated: 1606123137

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -44,6 +44,7 @@ namespace Unity.ProjectAuditor.Editor
     public enum IssueCategory
     {
         Assets,
+        Shaders,
         Code,
         ProjectSettings,
         NumCategories

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -36,7 +36,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         public bool showRightPanels;
         public GUIContent dependencyViewGuiContent;
         public IssueTable.Column[] columnDescriptors;
-        public ColumnStyle[] costumColumnStyles;
+        public ColumnStyle[] customColumnStyles;
         public Action<Location> onDoubleClick;
         public Action<ProblemDescriptor> onOpenDescriptor;
         public Action<ProjectIssue, DependencyNode> onDrawDependencies;
@@ -93,7 +93,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     style = Styles.Columns[(int)columnEnum];
                 else
                 {
-                    style = m_Desc.costumColumnStyles[columnEnum - IssueTable.Column.Custom];
+                    style = m_Desc.customColumnStyles[columnEnum - IssueTable.Column.Custom];
                 }
 
                 columns[i] = new MultiColumnHeaderState.Column

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -10,11 +10,18 @@ using UnityEngine.Profiling;
 
 namespace Unity.ProjectAuditor.Editor.UI
 {
+    enum PropertyFormat
+    {
+        String = 0,
+        Integer
+    }
+
     struct ColumnStyle
     {
         public GUIContent Content;
         public int Width;
         public int MinWidth;
+        public PropertyFormat Format;
     }
 
     struct AnalysisViewDescriptor
@@ -306,37 +313,43 @@ namespace Unity.ProjectAuditor.Editor.UI
                 {
                     Content = new GUIContent("Issue", "Issue description"),
                     Width = 300,
-                    MinWidth = 100
+                    MinWidth = 100,
+                    Format = PropertyFormat.String
                 },
                 new ColumnStyle
                 {
                     Content = new GUIContent(" ! ", "Issue priority"),
                     Width = 22,
-                    MinWidth = 22
+                    MinWidth = 22,
+                    Format = PropertyFormat.String
                 },
                 new ColumnStyle
                 {
                     Content = new GUIContent("Area", "The area the issue might have an impact on"),
                     Width = 60,
-                    MinWidth = 50
+                    MinWidth = 50,
+                    Format = PropertyFormat.String
                 },
                 new ColumnStyle
                 {
                     Content = new GUIContent("Path", "Path and line number"),
                     Width = 700,
-                    MinWidth = 100
+                    MinWidth = 100,
+                    Format = PropertyFormat.String
                 },
                 new ColumnStyle
                 {
                     Content = new GUIContent("Filename", "Managed Assembly name"),
                     Width = 180,
-                    MinWidth = 100
+                    MinWidth = 100,
+                    Format = PropertyFormat.String
                 },
                 new ColumnStyle
                 {
                     Content = new GUIContent("File Type", "File extension"),
                     Width = 80,
-                    MinWidth = 80
+                    MinWidth = 80,
+                    Format = PropertyFormat.String
                 }
             };
         }

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -499,7 +499,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                                 break;
                             default:
                                 var propertyIndex = columnEnum - Column.Custom;
-                                var format = m_ViewDescriptor.costumColumnStyles[propertyIndex].Format;
+                                var format = m_ViewDescriptor.customColumnStyles[propertyIndex].Format;
                                 if (format == PropertyFormat.Integer)
                                 {
                                     int first = -999999;

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -240,7 +240,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                             var guiContent = new GUIContent(text, tooltip);
 
 #if UNITY_2018_3_OR_NEWER
-                            if (m_Desc.descriptionWithIcon)
+                            if (m_Desc.descriptionWithIcon && issue.location != null)
                             {
                                 var icon = AssetDatabase.GetCachedIcon(issue.location.Path);
                                 guiContent = EditorGUIUtility.TrTextContentWithIcon(text, tooltip, icon);
@@ -459,8 +459,9 @@ namespace Unity.ProjectAuditor.Editor.UI
                             secondItem = a.m_Item;
                         }
 
-                        string firstString;
-                        string secondString;
+                        var firstString = String.Empty;
+                        var secondString = String.Empty;
+
                         var columnEnum = m_ViewDescriptor.columnDescriptors[columnSortOrder[i]];
                         switch (columnEnum)
                         {
@@ -498,12 +499,23 @@ namespace Unity.ProjectAuditor.Editor.UI
                                 break;
                             default:
                                 var propertyIndex = columnEnum - Column.Custom;
+                                var format = m_ViewDescriptor.costumColumnStyles[propertyIndex].Format;
+                                if (format == PropertyFormat.Integer)
+                                {
+                                    int first = -999999;
+                                    int second = -999999;
+                                    int.TryParse(firstItem.ProjectIssue.GetCustomProperty(propertyIndex), out first);
+                                    int.TryParse(secondItem.ProjectIssue.GetCustomProperty(propertyIndex), out second);
+                                    return first - second;
+                                }
+
                                 firstString = firstItem.ProjectIssue != null
                                     ? firstItem.ProjectIssue.GetCustomProperty(propertyIndex)
                                     : string.Empty;
                                 secondString = secondItem.ProjectIssue != null
                                     ? secondItem.ProjectIssue.GetCustomProperty(propertyIndex)
                                     : string.Empty;
+
                                 break;
                         }
 

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -502,10 +502,12 @@ namespace Unity.ProjectAuditor.Editor.UI
                                 var format = m_ViewDescriptor.customColumnStyles[propertyIndex].Format;
                                 if (format == PropertyFormat.Integer)
                                 {
-                                    int first = -999999;
-                                    int second = -999999;
-                                    int.TryParse(firstItem.ProjectIssue.GetCustomProperty(propertyIndex), out first);
-                                    int.TryParse(secondItem.ProjectIssue.GetCustomProperty(propertyIndex), out second);
+                                    int first;
+                                    int second;
+                                    if (!int.TryParse(firstItem.ProjectIssue.GetCustomProperty(propertyIndex), out first))
+                                        first = -999999;
+                                    if (int.TryParse(secondItem.ProjectIssue.GetCustomProperty(propertyIndex), out second))
+                                        second = -999999;
                                     return first - second;
                                 }
 

--- a/Editor/UI/ProjectAuditorAnalytics.cs
+++ b/Editor/UI/ProjectAuditorAnalytics.cs
@@ -42,7 +42,8 @@ namespace Unity.ProjectAuditor.Editor.UI
 
             ApiCalls = 100,
             ProjectSettings,
-            Assets
+            Assets,
+            Shaders
         }
 
         // -------------------------------------------------------------------------------------------------------------

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -51,7 +51,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     IssueTable.Column.FileType,
                     IssueTable.Column.Path
                 },
-                costumColumnStyles = new[]
+                customColumnStyles = new[]
                 {
                     new ColumnStyle
                     {
@@ -80,7 +80,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     IssueTable.Column.Custom,
                     IssueTable.Column.Custom + 1,
                 },
-                costumColumnStyles = new[]
+                customColumnStyles = new[]
                 {
                     new ColumnStyle
                     {
@@ -119,7 +119,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     IssueTable.Column.Filename,
                     IssueTable.Column.Custom
                 },
-                costumColumnStyles = new[]
+                customColumnStyles = new[]
                 {
                     new ColumnStyle
                     {

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -57,11 +57,48 @@ namespace Unity.ProjectAuditor.Editor.UI
                     {
                         Content = new GUIContent("Assembly", "Managed Assembly name"),
                         Width = 300,
-                        MinWidth = 100
+                        MinWidth = 100,
+                        Format = PropertyFormat.String
                     }
                 },
                 onDoubleClick = FocusOnAssetInProjectWindow,
                 analyticsEvent = ProjectAuditorAnalytics.UIButton.Assets
+            },
+            new AnalysisViewDescriptor
+            {
+                category = IssueCategory.Shaders,
+                name = "Shaders",
+                groupByDescription = true,
+                descriptionWithIcon = true,
+                showAssemblySelection = false,
+                showCritical = false,
+                showDependencyView = false,
+                showRightPanels = false,
+                columnDescriptors = new[]
+                {
+                    IssueTable.Column.Description,
+                    IssueTable.Column.Custom,
+                    IssueTable.Column.Custom + 1,
+                },
+                costumColumnStyles = new[]
+                {
+                    new ColumnStyle
+                    {
+                        Content = new GUIContent("Platform", "Shader Compiler Platform"),
+                        Width = 80,
+                        MinWidth = 80,
+                        Format = PropertyFormat.String
+                    },
+                    new ColumnStyle
+                    {
+                        Content = new GUIContent("Keywords", "Compiled Variants Keywords"),
+                        Width = 80,
+                        MinWidth = 80,
+                        Format = PropertyFormat.String
+                    },
+                },
+                onDoubleClick = FocusOnAssetInProjectWindow,
+                analyticsEvent = ProjectAuditorAnalytics.UIButton.Shaders
             },
             new AnalysisViewDescriptor
             {
@@ -88,7 +125,8 @@ namespace Unity.ProjectAuditor.Editor.UI
                     {
                         Content = new GUIContent("Assembly", "Managed Assembly name"),
                         Width = 300,
-                        MinWidth = 100
+                        MinWidth = 100,
+                        Format = PropertyFormat.String
                     }
                 },
                 onDoubleClick = OpenTextFile,
@@ -830,9 +868,8 @@ namespace Unity.ProjectAuditor.Editor.UI
         void DrawMode()
         {
             EditorGUILayout.BeginHorizontal();
-
             var activeModeIndex = GUILayout.Toolbar(m_ActiveModeIndex, m_ModeNames,
-                GUILayout.MaxWidth(LayoutSize.ModeTabWidth), GUILayout.Height(LayoutSize.ToolbarHeight));
+                "LargeButton", GUILayout.Height(LayoutSize.ToolbarHeight));
 
             EditorGUILayout.EndHorizontal();
 

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -82,7 +82,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                     new ColumnStyle
                     {
                         Content = new GUIContent("Keywords", "Compiled Variants Keywords"),
-                        Width = 80,
+                        Width = 800,
                         MinWidth = 80,
                         Format = PropertyFormat.String
                     },

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -198,7 +198,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         public virtual int callbackOrder { get; }
         public ShadersAuditor() {}
         public virtual void Audit(System.Action<Unity.ProjectAuditor.Editor.ProjectIssue> onIssueFound, System.Action onComplete, Unity.ProjectAuditor.Editor.IProgressBar progressBar = default(Unity.ProjectAuditor.Editor.IProgressBar));
-        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Auditors.ShadersAuditor.<GetDescriptors>d__1))] public virtual System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.ProblemDescriptor> GetDescriptors();
+        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Auditors.ShadersAuditor.<GetDescriptors>d__2))] public virtual System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.ProblemDescriptor> GetDescriptors();
         public virtual void Initialize(Unity.ProjectAuditor.Editor.ProjectAuditorConfig config);
         public virtual void OnPreprocessBuild(UnityEditor.Build.Reporting.BuildReport report);
         public virtual void OnProcessShader(UnityEngine.Shader shader, UnityEditor.Rendering.ShaderSnippetData snippet, System.Collections.Generic.IList<UnityEditor.Rendering.ShaderCompilerData> data);

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -66,9 +66,10 @@ namespace Unity.ProjectAuditor.Editor
     public enum IssueCategory
     {
         public const Unity.ProjectAuditor.Editor.IssueCategory Assets = 0;
-        public const Unity.ProjectAuditor.Editor.IssueCategory Code = 1;
-        public const Unity.ProjectAuditor.Editor.IssueCategory NumCategories = 3;
-        public const Unity.ProjectAuditor.Editor.IssueCategory ProjectSettings = 2;
+        public const Unity.ProjectAuditor.Editor.IssueCategory Code = 2;
+        public const Unity.ProjectAuditor.Editor.IssueCategory NumCategories = 4;
+        public const Unity.ProjectAuditor.Editor.IssueCategory ProjectSettings = 3;
+        public const Unity.ProjectAuditor.Editor.IssueCategory Shaders = 1;
         public int value__;
     }
 
@@ -188,6 +189,19 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         public virtual void Audit(System.Action<Unity.ProjectAuditor.Editor.ProjectIssue> onIssueFound, System.Action onComplete, Unity.ProjectAuditor.Editor.IProgressBar progressBar = default(Unity.ProjectAuditor.Editor.IProgressBar));
         public virtual System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.ProblemDescriptor> GetDescriptors();
         public virtual void Initialize(Unity.ProjectAuditor.Editor.ProjectAuditorConfig config);
+        public virtual void RegisterDescriptor(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor);
+        public virtual void Reload(string path);
+    }
+
+    public class ShadersAuditor : Unity.ProjectAuditor.Editor.IAuditor, UnityEditor.Build.IOrderedCallback, UnityEditor.Build.IPreprocessBuildWithReport, UnityEditor.Build.IPreprocessShaders
+    {
+        public virtual int callbackOrder { get; }
+        public ShadersAuditor() {}
+        public virtual void Audit(System.Action<Unity.ProjectAuditor.Editor.ProjectIssue> onIssueFound, System.Action onComplete, Unity.ProjectAuditor.Editor.IProgressBar progressBar = default(Unity.ProjectAuditor.Editor.IProgressBar));
+        [System.Runtime.CompilerServices.IteratorStateMachine(typeof(Unity.ProjectAuditor.Editor.Auditors.ShadersAuditor.<GetDescriptors>d__1))] public virtual System.Collections.Generic.IEnumerable<Unity.ProjectAuditor.Editor.ProblemDescriptor> GetDescriptors();
+        public virtual void Initialize(Unity.ProjectAuditor.Editor.ProjectAuditorConfig config);
+        public virtual void OnPreprocessBuild(UnityEditor.Build.Reporting.BuildReport report);
+        public virtual void OnProcessShader(UnityEngine.Shader shader, UnityEditor.Rendering.ShaderSnippetData snippet, System.Collections.Generic.IList<UnityEditor.Rendering.ShaderCompilerData> data);
         public virtual void RegisterDescriptor(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor);
         public virtual void Reload(string path);
     }

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor;
+
+namespace UnityEditor.ProjectAuditor.EditorTests
+{
+    class ShaderTests
+    {
+        ScriptResource m_ShaderResource;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            m_ShaderResource = new ScriptResource("Resources/MyTestShader.shader", @"
+Shader ""Custom/MyTestShader""
+            {
+                Properties
+                {
+                    _Color (""Color"", Color) = (1,1,1,1)
+                }
+                SubShader
+                {
+                    Tags { ""RenderType""=""Opaque"" }
+                    LOD 200
+
+                    CGPROGRAM
+                    // Physically based Standard lighting model, and enable shadows on all light types
+                    #pragma surface surf Standard fullforwardshadows
+
+                    // Use shader model 3.0 target, to get nicer looking lighting
+                    #pragma target 3.0
+
+                    sampler2D _MainTex;
+
+                    struct Input
+                    {
+                        float2 uv_MainTex;
+                    };
+
+                    half _Glossiness;
+                    half _Metallic;
+                    fixed4 _Color;
+
+                    void surf (Input IN, inout SurfaceOutputStandard o)
+                    {
+                        // Albedo comes from a texture tinted by color
+                        fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+                        o.Albedo = c.rgb;
+                        // Metallic and smoothness come from slider variables
+                        o.Metallic = _Metallic;
+                        o.Smoothness = _Glossiness;
+                        o.Alpha = c.a;
+                    }
+                    ENDCG
+                }
+                FallBack ""Diffuse""
+            }
+");
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            m_ShaderResource.Delete();
+        }
+
+        [Test]
+        public void BuildIsRequired()
+        {
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
+
+            var projectReport = projectAuditor.Audit();
+            var issues = projectReport.GetIssues(IssueCategory.Shaders);
+            issues = issues;
+            Assert.Positive(issues.Length);
+            Assert.True(issues.First().description.Equals("Build the project and run Project Auditor analysis"));
+        }
+
+        [Test]
+        public void ShaderVariantsAreReported()
+        {
+            var targetPath = FileUtil.GetUniqueTempPathInProject();
+            Directory.CreateDirectory(targetPath);
+            var buildPlayerOptions = new BuildPlayerOptions
+            {
+                scenes = new string[] {},
+                locationPathName = targetPath,
+                target = EditorUserBuildSettings.activeBuildTarget,
+                options = BuildOptions.Development
+            };
+            var buildReport = BuildPipeline.BuildPlayer(buildPlayerOptions);
+
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
+
+            var projectReport = projectAuditor.Audit();
+            var issues = projectReport.GetIssues(IssueCategory.Shaders);
+            issues = issues.Where(i => i.description.Equals("Custom/MyTestShader")).ToArray();
+            Assert.AreEqual(42, issues.Length);
+
+            Directory.Delete(targetPath);
+        }
+    }
+}

--- a/Tests/Editor/ShaderTests.cs.meta
+++ b/Tests/Editor/ShaderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a7e5f6cb28844fc8ba621c57bc9f3d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is the first iteration on the Shaders auditor. The objective of this auditor is to provide a list of all shaders and variants included in the build for the current active platform. The UI displays all shader variants grouped by the shader they belong to.
Since this analysis is based on the variants required by the scene in the project, the user must build at least once before being able to see valid data in the Shaders view.
![variants-2](https://user-images.githubusercontent.com/12098182/100091589-b55b8c00-2e4c-11eb-9533-e4fd4131e1bb.png)
