### PR TITLE
Reuse collision callbacks support

### DIFF
--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -279,6 +279,16 @@
           "area": "BuildSize",
           "problem": "The \"Texture MipMap Stripping\" option in Player Settings is disabled. The generated build might be larger than necessary. ",
           "solution": "Enable Texture MipMap stripping. Note that this feature will only reduce the build size if no quality levels on the platform use highest mip(s). Furthermore, if code drives the \"masterTextureLevel\" to a value higher than those in the quality level settings the mip will no longer be available if this is enabled."
+        },
+        {
+          "id": 201028,
+          "description": "Physics: Reuse Collision Callbacks",
+          "type": "UnityEngine.Physics",
+          "method": "reuseCollisionCallbacks",
+          "value": "False",
+          "area": "Memory",
+          "problem": "The \"Reuse Collision Callbacks\" option in Physics Settings is disabled. For each OnCollision* callback, a temporary managed object is allocated which, eventually, will need to be garbage collected.",
+          "solution": "When this option is enabled, only a single instance of the Collision type is created and reused for each individual callback. This reduces waste for the garbage collector to handle and improves performance."
         }
     ]
 }


### PR DESCRIPTION
Report if _UnityEngine.Physics.reuseCollisionCallbacks_ is disabled, since it leads to short-lived managed allocations that eventually need to be garbage collected.