### PR TITLE
Shader Variants fix and tests

### DIFF
--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -15,6 +15,22 @@ using UnityEngine.Rendering;
 
 namespace Unity.ProjectAuditor.Editor.Auditors
 {
+    public enum ShaderProperty
+    {
+        NumVariants = 0,
+        NumPasses,
+        NumKeywords,
+        RenderQueue,
+        Instancing
+    }
+
+    public enum ShaderVariantProperty
+    {
+        Platform = 0,
+        PassName,
+        Keywords
+    }
+
     class ShaderVariantData
     {
         public string passName;
@@ -243,7 +259,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             s_ShaderVariantData = null;
         }
 
-        public int callbackOrder { get { return 0; } }
+        public int callbackOrder { get { return Int32.MaxValue; } }
         public void OnPreprocessBuild(BuildReport report)
         {
             s_ShaderVariantData = new Dictionary<Shader, List<ShaderVariantData>>();

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -197,6 +197,16 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         public virtual void Reload(string path);
     }
 
+    public enum ShaderProperty
+    {
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderProperty Instancing = 4;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderProperty NumKeywords = 2;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderProperty NumPasses = 1;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderProperty NumVariants = 0;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderProperty RenderQueue = 3;
+        public int value__;
+    }
+
     public class ShadersAuditor : Unity.ProjectAuditor.Editor.IAuditor, UnityEditor.Build.IOrderedCallback, UnityEditor.Build.IPreprocessBuildWithReport, UnityEditor.Build.IPreprocessShaders
     {
         public virtual int callbackOrder { get; }
@@ -208,6 +218,14 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         public virtual void OnProcessShader(UnityEngine.Shader shader, UnityEditor.Rendering.ShaderSnippetData snippet, System.Collections.Generic.IList<UnityEditor.Rendering.ShaderCompilerData> data);
         public virtual void RegisterDescriptor(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor);
         public virtual void Reload(string path);
+    }
+
+    public enum ShaderVariantProperty
+    {
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Keywords = 2;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PassName = 1;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Platform = 0;
+        public int value__;
     }
 }
 

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -11,7 +11,6 @@ using UnityEngine.Rendering;
 
 namespace UnityEditor.ProjectAuditor.EditorTests
 {
-
     class ShaderTests
     {
         TempAsset m_ShaderResource;
@@ -189,7 +188,7 @@ Shader ""Custom/MyEditorShader""
             Directory.CreateDirectory(buildPath);
             var buildPlayerOptions = new BuildPlayerOptions
             {
-                scenes = new string[] { },
+                scenes = new string[] {},
                 locationPathName = Path.Combine(buildPath, "test"),
                 target = EditorUserBuildSettings.activeBuildTarget,
                 targetGroup = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget),
@@ -209,6 +208,7 @@ Shader ""Custom/MyEditorShader""
             Assert.Positive(issues.Length);
             return issues;
         }
+
 #endif
 
         [Test]

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -1,15 +1,50 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
 using Unity.ProjectAuditor.Editor.Auditors;
+using UnityEditor.Build;
+using UnityEditor.Rendering;
+using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace UnityEditor.ProjectAuditor.EditorTests
 {
+
     class ShaderTests
     {
         TempAsset m_ShaderResource;
         TempAsset m_EditorShaderResource;
+
+#if UNITY_2018_2_OR_NEWER
+        private static string s_KeywordName = "DIRECTIONAL";
+
+        class StripVariants : IPreprocessShaders
+        {
+            static public bool Enabled = false;
+            public int callbackOrder { get { return 0; } }
+
+            public void OnProcessShader(
+                Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> shaderCompilerData)
+            {
+                if (!Enabled)
+                    return;
+
+                var keyword = new ShaderKeyword(s_KeywordName);
+
+                for (int i = 0; i < shaderCompilerData.Count; ++i)
+                {
+                    if (shaderCompilerData[i].shaderKeywordSet.IsEnabled(keyword))
+                    {
+                        shaderCompilerData.RemoveAt(i);
+                        --i;
+                    }
+                }
+            }
+        }
+#endif
+
 
         [OneTimeSetUp]
         public void SetUp()
@@ -129,11 +164,32 @@ Shader ""Custom/MyEditorShader""
         [Test]
         public void ShaderVariantsAreReported()
         {
+            var issues = BuildAndAnalyze();
+
+            var keywords = issues.Select(i => i.GetCustomProperty((int)ShaderVariantProperty.Keywords));
+
+            Assert.True(keywords.Any(key => key.Equals(s_KeywordName)));
+        }
+
+        [Test]
+        public void StrippedVariantsAreNotReported()
+        {
+            StripVariants.Enabled = true;
+            var issues = BuildAndAnalyze();
+            StripVariants.Enabled = false;
+
+            var keywords = issues.Select(i => i.GetCustomProperty((int)ShaderVariantProperty.Keywords));
+
+            Assert.False(keywords.Any(key => key.Equals(s_KeywordName)));
+        }
+
+        private static ProjectIssue[] BuildAndAnalyze()
+        {
             var buildPath = FileUtil.GetUniqueTempPathInProject();
             Directory.CreateDirectory(buildPath);
             var buildPlayerOptions = new BuildPlayerOptions
             {
-                scenes = new string[] {},
+                scenes = new string[] { },
                 locationPathName = Path.Combine(buildPath, "test"),
                 target = EditorUserBuildSettings.activeBuildTarget,
                 targetGroup = BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget),
@@ -151,6 +207,7 @@ Shader ""Custom/MyEditorShader""
             issues = issues.Where(i => i.description.Equals("Custom/MyTestShader")).ToArray();
 
             Assert.Positive(issues.Length);
+            return issues;
         }
 #endif
 


### PR DESCRIPTION
If a project strips variants with a _OnProcessShader_ callback, Project Auditor might still report stripped variants. This PR changes the order of its own callback so that it's executes last.