### PR TITLE
Add Requirements column to Shader Variants window

### DIFF
--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -30,6 +30,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         Platform = 0,
         PassName,
         Keywords,
+        Requirements,
         Num
     }
 
@@ -255,6 +256,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                     compilerData.shaderCompilerPlatform.ToString(),
                     shaderVariantData.passName,
                     keywordString,
+                    compilerData.shaderRequirements.ToString()
                 });
 
                 onIssueFound(issue);

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -170,7 +170,8 @@ namespace Unity.ProjectAuditor.Editor
         internal int GetCustomPropertyAsInt(int index)
         {
             var valueAsString = GetCustomProperty(index);
-            var value = int.Parse(valueAsString);
+            if (!int.TryParse(valueAsString, out var value))
+                return 0;
             return value;
         }
 

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -170,7 +170,8 @@ namespace Unity.ProjectAuditor.Editor
         internal int GetCustomPropertyAsInt(int index)
         {
             var valueAsString = GetCustomProperty(index);
-            if (!int.TryParse(valueAsString, out var value))
+            var value = 0;
+            if (!int.TryParse(valueAsString, out value))
                 return 0;
             return value;
         }

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -167,6 +167,13 @@ namespace Unity.ProjectAuditor.Editor
             return customProperties != null ? customProperties[index] : string.Empty;
         }
 
+        internal int GetCustomPropertyAsInt(int index)
+        {
+            var valueAsString = GetCustomProperty(index);
+            var value = int.Parse(valueAsString);
+            return value;
+        }
+
         public void SetCustomProperties(string[] properties)
         {
             customProperties = properties;

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -199,7 +199,8 @@ namespace Unity.ProjectAuditor.Editor.UI
                 IssueTable.Column.Description,
                 IssueTable.Column.Custom,
                 IssueTable.Column.Custom + 1,
-                IssueTable.Column.Custom + 2
+                IssueTable.Column.Custom + 2,
+                IssueTable.Column.Custom + 3
             },
             descriptionColumnStyle = new ColumnStyle
             {
@@ -228,6 +229,13 @@ namespace Unity.ProjectAuditor.Editor.UI
                 {
                     Content = new GUIContent("Keywords", "Compiled Variants Keywords"),
                     Width = 800,
+                    MinWidth = 80,
+                    Format = PropertyFormat.String
+                },
+                new ColumnStyle
+                {
+                    Content = new GUIContent("Requirements"),
+                    Width = 500,
                     MinWidth = 80,
                     Format = PropertyFormat.String
                 }

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -232,9 +232,10 @@ namespace Unity.ProjectAuditor.Editor.Auditors
     public enum ShaderVariantProperty
     {
         public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Keywords = 2;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Num = 3;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Num = 4;
         public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PassName = 1;
         public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Platform = 0;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Requirements = 3;
         public int value__;
     }
 }

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -301,9 +301,11 @@ Shader ""Custom/MyEditorShader""
 
             // check custom properties
             Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("<no keywords>")), "No shader variants found without INSTANCING_ON keyword");
-            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("INSTANCING_ON")), "No shader variants found with INSTANCING_ON keyword");
             Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives")), "No shader variants found without Instancing requirement");
+#if UNITY_2019_1_OR_NEWER
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("INSTANCING_ON")), "No shader variants found with INSTANCING_ON keyword");
             Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives, Instancing")), "No shader variants found with Instancing requirement");
+#endif
         }
 
         [Test]
@@ -371,8 +373,13 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
+#if UNITY_2019_1_OR_NEWER
             Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
             Assert.AreEqual(2, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+#else
+            Assert.AreEqual(0, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(0, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+#endif
             Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("No"));
         }
@@ -388,8 +395,13 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
+#if UNITY_2019_1_OR_NEWER
             Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
             Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+#else
+            Assert.AreEqual(0, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(0, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+#endif
             Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
         }
@@ -405,8 +417,13 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
+#if UNITY_2019_1_OR_NEWER
             Assert.AreEqual(4, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
             Assert.AreEqual(22, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+#else
+            Assert.AreEqual(0, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(0, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+#endif
             Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
         }

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -297,13 +297,13 @@ Shader ""Custom/MyEditorShader""
             Assert.True(keywords.Any(key => key.Equals(s_KeywordName)));
 
             var variants = issues.Where(i => i.description.Equals("Custom/ShaderUsingBuiltInKeyword"));
-            Assert.Positive(variants.Count());
+            Assert.Positive(variants.Count(), "No shader variants found");
 
             // check custom properties
-            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("INSTANCING_ON")));
-            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("<no keywords>"))); // check for instancing-off variant
-            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives")));
-            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives, Instancing")));
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("<no keywords>")), "No shader variants found without INSTANCING_ON keyword");
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("INSTANCING_ON")), "No shader variants found with INSTANCING_ON keyword");
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives")), "No shader variants found without Instancing requirement");
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives, Instancing")), "No shader variants found with Instancing requirement");
         }
 
         [Test]

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -21,6 +21,9 @@ namespace UnityEditor.ProjectAuditor.EditorTests
         TempAsset m_ShaderResource;
         TempAsset m_EditorShaderResource;
 
+        TempAsset m_ShaderUsingBuiltInKeywordResource;
+        TempAsset m_SurfShaderResource;
+
 #if UNITY_2018_2_OR_NEWER
         static string s_KeywordName = "DIRECTIONAL";
 
@@ -54,7 +57,108 @@ namespace UnityEditor.ProjectAuditor.EditorTests
         public void SetUp()
         {
             m_ShaderResource = new TempAsset("Resources/MyTestShader.shader", @"
-Shader ""Custom/MyTestShader""
+            Shader ""Custom/MyTestShader""
+            {
+                SubShader
+                {
+                    Pass
+                    {
+                        Name ""MyTestShader/Pass""
+
+                        CGPROGRAM
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma multi_compile KEYWORD_A KEYWORD_B
+
+                        struct appdata
+                        {
+                            float4 vertex : POSITION;
+                            float2 uv : TEXCOORD0;
+                        };
+
+                        struct v2f
+                        {
+                            float2 uv : TEXCOORD0;
+                            float4 vertex : SV_POSITION;
+                        };
+
+                        sampler2D _MainTex;
+                        float4 _MainTex_ST;
+
+                        v2f vert (appdata v)
+                        {
+                            v2f o;
+                            o.vertex = UnityObjectToClipPos(v.vertex);
+                            o.uv = v.uv;
+                            return o;
+                        }
+
+                        fixed4 frag (v2f i) : SV_Target
+                        {
+                            return tex2D(_MainTex, i.uv);
+                        }
+                        ENDCG
+                    }
+                }
+            }");
+
+
+            m_ShaderUsingBuiltInKeywordResource = new TempAsset("Resources/ShaderUsingBuiltInKeyword.shader", @"
+Shader ""Custom/ShaderUsingBuiltInKeyword""
+            {
+                Properties
+                {
+                    _MainTex (""Texture"", 2D) = ""white"" {}
+                }
+                SubShader
+                {
+                    Tags { ""RenderType""=""Opaque"" }
+                    LOD 100
+
+                    Pass
+                    {
+                        CGPROGRAM
+#pragma vertex vert
+#pragma fragment frag
+#pragma multi_compile_instancing
+
+#include ""UnityCG.cginc""
+
+                        struct appdata
+                        {
+                            float4 vertex : POSITION;
+                            float2 uv : TEXCOORD0;
+                        };
+
+                        struct v2f
+                        {
+                            float2 uv : TEXCOORD0;
+                            float4 vertex : SV_POSITION;
+                        };
+
+                        sampler2D _MainTex;
+                        float4 _MainTex_ST;
+
+                        v2f vert (appdata v)
+                        {
+                            v2f o;
+                            o.vertex = UnityObjectToClipPos(v.vertex);
+                            o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                            return o;
+                        }
+
+                        fixed4 frag (v2f i) : SV_Target
+                        {
+                            return tex2D(_MainTex, i.uv);
+                        }
+                        ENDCG
+                    }
+                }
+            }
+            ");
+
+            m_SurfShaderResource = new TempAsset("Resources/MySurfShader.shader", @"
+Shader ""Custom/MySurfShader""
             {
                 Properties
                 {
@@ -178,9 +282,45 @@ Shader ""Custom/MyEditorShader""
             Assert.Positive(variants.Count());
 
             // check custom property
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("KEYWORD_A")));
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("KEYWORD_B")));
+            Assert.AreEqual((int)ShaderVariantProperty.Num, variants.First().GetNumCustomProperties());
+        }
+
+        [Test]
+        public void ShaderVariantForBuiltInKeywordIsReported()
+        {
+            var issues = BuildAndAnalyze();
+
+            var keywords = issues.Select(i => i.GetCustomProperty((int)ShaderVariantProperty.Keywords));
+
+            Assert.True(keywords.Any(key => key.Equals(s_KeywordName)));
+
+            var variants = issues.Where(i => i.description.Equals("Custom/ShaderUsingBuiltInKeyword"));
+            Assert.Positive(variants.Count());
+
+            // check custom properties
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("INSTANCING_ON")));
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("<no keywords>"))); // check for instancing-off variant
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives")));
+            Assert.True(variants.Any(v => v.GetCustomProperty((int)ShaderVariantProperty.Requirements).Equals("BaseShaders, Derivatives, Instancing")));
+        }
+
+        [Test]
+        public void SurfShaderVariantsAreReported()
+        {
+            var issues = BuildAndAnalyze();
+
+            var keywords = issues.Select(i => i.GetCustomProperty((int)ShaderVariantProperty.Keywords));
+
+            Assert.True(keywords.Any(key => key.Equals(s_KeywordName)));
+
+            var variants = issues.Where(i => i.description.Equals("Custom/MySurfShader"));
+            Assert.Positive(variants.Count());
+
+            // check custom property
             var variant = variants.FirstOrDefault(v => v.GetCustomProperty((int)ShaderVariantProperty.PassName).Equals("FORWARD") && v.GetCustomProperty((int)ShaderVariantProperty.Keywords).Equals("DIRECTIONAL"));
             Assert.NotNull(variant);
-            Assert.AreEqual((int)ShaderVariantProperty.Num, variant.GetNumCustomProperties());
         }
 
         [Test]
@@ -215,11 +355,7 @@ Shader ""Custom/MyEditorShader""
 
             var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
             var projectReport = projectAuditor.Audit();
-            var issues = projectReport.GetIssues(IssueCategory.ShaderVariants);
-            issues = issues.Where(i => i.description.Equals("Custom/MyTestShader")).ToArray();
-
-            Assert.Positive(issues.Length);
-            return issues;
+            return projectReport.GetIssues(IssueCategory.ShaderVariants);
         }
 
 #endif
@@ -235,7 +371,40 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumVariants).Equals("N/A"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses).Equals("1"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords).Equals("2"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue).Equals("2000"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("No"));
+        }
+
+        [Test]
+        public void ShaderUsingBuiltInKeywordIsReported()
+        {
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
+            var projectReport = projectAuditor.Audit();
+            var issues = projectReport.GetIssues(IssueCategory.Shaders);
+            var shaderIssue = issues.FirstOrDefault(i => i.description.Equals("Custom/ShaderUsingBuiltInKeyword"));
+            Assert.NotNull(shaderIssue);
+
+            // check custom property
+            Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses).Equals("1"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords).Equals("1"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue).Equals("2000"));
+            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
+        }
+
+        [Test]
+        public void SurfShaderIsReported()
+        {
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
+            var projectReport = projectAuditor.Audit();
+            var issues = projectReport.GetIssues(IssueCategory.Shaders);
+            var shaderIssue = issues.FirstOrDefault(i => i.description.Equals("Custom/MySurfShader"));
+            Assert.NotNull(shaderIssue);
+
+            // check custom property
+            Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses).Equals("4"));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords).Equals("22"));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue).Equals("2000"));

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -371,9 +371,9 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses));
-            Assert.AreEqual(2, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords));
-            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue));
+            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(2, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("No"));
         }
 
@@ -388,10 +388,9 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-
-            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses));
-            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords));
-            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue));
+            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
         }
 
@@ -406,9 +405,9 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-            Assert.AreEqual(4, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses));
-            Assert.AreEqual(22, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords));
-            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue));
+            Assert.AreEqual(4, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses), "NumPasses was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(22, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords), "NumKeywords was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords));
+            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
         }
 

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -371,9 +371,9 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses).Equals("1"));
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords).Equals("2"));
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue).Equals("2000"));
+            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(2, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords));
+            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("No"));
         }
 
@@ -388,9 +388,10 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses).Equals("1"));
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords).Equals("1"));
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue).Equals("2000"));
+
+            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(1, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords));
+            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
         }
 
@@ -405,9 +406,9 @@ Shader ""Custom/MyEditorShader""
 
             // check custom property
             Assert.AreEqual((int)ShaderProperty.Num, shaderIssue.GetNumCustomProperties());
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumPasses).Equals("4"));
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.NumKeywords).Equals("22"));
-            Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue).Equals("2000"));
+            Assert.AreEqual(4, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumPasses));
+            Assert.AreEqual(22, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.NumKeywords));
+            Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("Yes"));
         }
 


### PR DESCRIPTION
**Problem**
Some reported variants of the same shader seem duplicate because they have the same keywords. It turns out Unity produces multiple variants with the same keywords based on the required features of the shader. For more information check [here](https://docs.unity3d.com/ScriptReference/Rendering.ShaderRequirements.html).

**Solution**
This PR adds a Requirements column to the Shader Variants window.
<img width="1197" alt="requirements" src="https://user-images.githubusercontent.com/12098182/103899574-7f1d5780-50ee-11eb-8d09-641109b6dfc0.png">
