### PR TITLE
Shaders error reporting

### DIFF
--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -55,7 +55,10 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             Area.BuildSize,
             string.Empty,
             string.Empty
-            );
+            )
+        {
+            severity = Rule.Severity.Error
+        };
 
         ProblemDescriptor k_BuildRequiredDescriptor = new ProblemDescriptor
             (
@@ -64,7 +67,10 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             Area.BuildSize,
             string.Empty,
             string.Empty
-            );
+            )
+        {
+            severity = Rule.Severity.Error
+        };
 
         const int k_ShaderVariantFirstId = 400002;
 

--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -72,6 +72,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             severity = Rule.Severity.Error
         };
 
+        const string k_NotAvailable = "N/A";
         const int k_ShaderVariantFirstId = 400002;
 
         static Dictionary<Shader, List<ShaderVariantData>> s_ShaderVariantData;
@@ -179,8 +180,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
         void AddShader(Shader shader, string assetPath, int id, Action<ProjectIssue> onIssueFound)
         {
-            const string NotAvailable = "N/A";
-            var variantCount = NotAvailable;
+            var variantCount = k_NotAvailable;
 
 #if UNITY_2018_2_OR_NEWER
             // add variants first
@@ -199,29 +199,42 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 #endif
 
             var shaderName = shader.name;
-            ProblemDescriptor descriptor;
+            var shaderHasError = false;
+
 #if UNITY_2019_4_OR_NEWER
-            if (ShaderUtil.ShaderHasError(shader))
+            shaderHasError = ShaderUtil.ShaderHasError(shader);
+#endif
+
+            if (shaderHasError)
             {
                 shaderName = Path.GetFileNameWithoutExtension(assetPath) + ": Parse Error";
-                descriptor = k_ParseErrorDescriptor;
-            }
-            else
-#endif
-            {
-                descriptor = new ProblemDescriptor
-                    (
-                    id++,
-                    shaderName,
-                    Area.BuildSize,
-                    string.Empty,
-                    string.Empty
-                    );
+
+                var issueWithError = new ProjectIssue(k_ParseErrorDescriptor, shaderName, IssueCategory.Shaders, new Location(assetPath));
+                issueWithError.SetCustomProperties(new[]
+                {
+                    k_NotAvailable,
+                    k_NotAvailable,
+                    k_NotAvailable,
+                    k_NotAvailable,
+                    k_NotAvailable,
+                });
+                onIssueFound(issueWithError);
+
+                return;
             }
 
-            var passCount = NotAvailable;
-            var keywordCount = NotAvailable;
-            var hasInstancing = NotAvailable;
+            var descriptor = new ProblemDescriptor
+                (
+                id++,
+                shaderName,
+                Area.BuildSize,
+                string.Empty,
+                string.Empty
+                );
+
+            var passCount = k_NotAvailable;
+            var keywordCount = k_NotAvailable;
+            var hasInstancing = k_NotAvailable;
 /*
             var usedBySceneOnly = false;
             if (m_GetShaderVariantCountMethod != null)

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -74,6 +74,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                 showRightPanels = false,
                 columnTypes = new[]
                 {
+                    IssueTable.ColumnType.Severity,
                     IssueTable.ColumnType.Description,
                     IssueTable.ColumnType.Custom,
                     IssueTable.ColumnType.Custom + 1,

--- a/Tests/Editor/ShaderTests.cs
+++ b/Tests/Editor/ShaderTests.cs
@@ -19,6 +19,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
     class ShaderTests
     {
         TempAsset m_ShaderResource;
+        TempAsset m_ShaderWithErrorResource;
         TempAsset m_EditorShaderResource;
 
         TempAsset m_ShaderUsingBuiltInKeywordResource;
@@ -102,6 +103,10 @@ namespace UnityEditor.ProjectAuditor.EditorTests
                 }
             }");
 
+            m_ShaderWithErrorResource = new TempAsset("Resources/ShaderWithError.shader", @"
+            Sader ""Custom/ShaderWithError""
+            {
+            }");
 
             m_ShaderUsingBuiltInKeywordResource = new TempAsset("Resources/ShaderUsingBuiltInKeyword.shader", @"
 Shader ""Custom/ShaderUsingBuiltInKeyword""
@@ -382,6 +387,18 @@ Shader ""Custom/MyEditorShader""
 #endif
             Assert.AreEqual(2000, shaderIssue.GetCustomPropertyAsInt((int)ShaderProperty.RenderQueue), "RenderQueue was : " + shaderIssue.GetCustomProperty((int)ShaderProperty.RenderQueue));
             Assert.True(shaderIssue.GetCustomProperty((int)ShaderProperty.Instancing).Equals("No"));
+        }
+
+        [Test]
+        public void ShaderWithErrorIsReported()
+        {
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor();
+            var projectReport = projectAuditor.Audit();
+            var issues = projectReport.GetIssues(IssueCategory.Shaders);
+            var shadersWithErrors = issues.Where(i => i.severity == Rule.Severity.Error);
+            Assert.Positive(shadersWithErrors.Count());
+            var shaderIssue = issues.FirstOrDefault(i => i.relativePath.Equals(m_ShaderWithErrorResource.relativePath));
+            Assert.NotNull(shaderIssue);
         }
 
         [Test]


### PR DESCRIPTION
**Problem**
If a shader contains errors, it is not easy to spot that among lots of other shaders.

**Solution**
This PR adds a _severity_ column which will display an error icon next to the malformed shader.
![shader-error](https://user-images.githubusercontent.com/12098182/104217617-85d00580-5433-11eb-962c-7961dbe69544.PNG)
