### PR TITLE
Fix failure to detect call to tag property

### DIFF
--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -1833,6 +1833,14 @@
           "critical": true,
           "problem": "WarmUp does not work properly on Metal and Vulkan. This might result in unexpected CPU spikes due to shader compilation.",
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader variant used at runtime."
+        },
+        {
+          "id": 101229,
+          "type": "UnityEngine.Component",
+          "method": "tag",
+          "area": "Memory",
+          "problem": "The Component.tag property allocates managed memory.",
+          "solution": "Try to avoid getting this property in frequently-updated code. Prefer using CompareTag() instead, as this does not result in managed allocations."
         }
     ]
 }

--- a/Editor/InstructionAnalyzers/BuiltinInstructionAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BuiltinInstructionAnalyzer.cs
@@ -4,17 +4,29 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Unity.ProjectAuditor.Editor.CodeAnalysis;
+using UnityEngine;
 
 namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 {
     class BuiltinInstructionAnalyzer : IInstructionAnalyzer
     {
-        Dictionary<string, ProblemDescriptor> m_Descriptors; // type+method name as key
+        Dictionary<string, List<ProblemDescriptor>> m_Descriptors; // method name as key, list of type names as value
         Dictionary<string, ProblemDescriptor> m_WholeNamespaceDescriptors; // namespace as key
 
         public void Initialize(IAuditor auditor)
         {
-            m_Descriptors = auditor.GetDescriptors().Where(descriptor => !descriptor.method.Equals("*") && !string.IsNullOrEmpty(descriptor.type)).ToDictionary(descriptor => descriptor.type + "." + descriptor.method);
+            var descriptors = auditor.GetDescriptors().Where(descriptor => !descriptor.method.Equals("*") && !string.IsNullOrEmpty(descriptor.type));
+
+            m_Descriptors = new Dictionary<string, List<ProblemDescriptor>>();
+            foreach (var d in descriptors)
+            {
+                if (!m_Descriptors.ContainsKey(d.method))
+                {
+                    m_Descriptors.Add(d.method, new List<ProblemDescriptor>());
+                }
+                m_Descriptors[d.method].Add(d);
+            }
+
             m_WholeNamespaceDescriptors = auditor.GetDescriptors().Where(descriptor => descriptor.method.Equals("*")).ToDictionary(d => d.type);
         }
 
@@ -31,22 +43,24 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
             if (methodName.StartsWith("get_"))
                 methodName = methodName.Substring("get_".Length);
 
-            m_Descriptors.TryGetValue(callee.DeclaringType.FullName + "." + methodName, out descriptor);
+            // Are we trying to warn about a whole namespace?
+            m_WholeNamespaceDescriptors.TryGetValue(callee.DeclaringType.Namespace, out descriptor);
             if (descriptor != null)
             {
-                // by default use descriptor issue description
-                description = descriptor.description;
+                description = calleeNode.prettyName;
             }
             else
             {
-                // Are we trying to warn about a whole namespace?
-                m_WholeNamespaceDescriptors.TryGetValue(callee.DeclaringType.Namespace, out descriptor);
-                if (descriptor == null)
-                    // no issue found
+                List<ProblemDescriptor> descriptors;
+                if (!m_Descriptors.TryGetValue(methodName, out descriptors))
                     return null;
 
-                // use callee name since it's more informative
-                description = calleeNode.prettyName;
+                descriptor = descriptors.Find(d => IsOrInheritedFrom(callee.DeclaringType, d.type));
+                if (descriptor == null)
+                    return null;
+
+                // by default use descriptor issue description
+                description = descriptor.description;
             }
 
             return new ProjectIssue
@@ -62,6 +76,26 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
         {
             yield return OpCodes.Call;
             yield return OpCodes.Callvirt;
+        }
+
+        static bool IsOrInheritedFrom(TypeReference typeReference, string typeName)
+        {
+            try
+            {
+                var typeDefinition = typeReference.Resolve();
+
+                if (typeDefinition.FullName.Equals(typeName))
+                    return true;
+
+                if (typeDefinition.BaseType != null)
+                    return IsOrInheritedFrom(typeDefinition.BaseType, typeName);
+            }
+            catch (AssemblyResolutionException e)
+            {
+                Debug.LogWarning(e);
+            }
+
+            return false;
         }
     }
 }

--- a/Tests/Editor/ScriptIssueTestHelper.cs
+++ b/Tests/Editor/ScriptIssueTestHelper.cs
@@ -10,7 +10,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 {
     public static class ScriptIssueTestHelper
     {
-        public static IEnumerable<ProjectIssue> AnalyzeAndFindScriptIssues(TempAsset tempAsset)
+        public static ProjectIssue[] AnalyzeAndFindScriptIssues(TempAsset tempAsset)
         {
             var auditor = new ScriptAuditor();
             var config = ScriptableObject.CreateInstance<ProjectAuditorConfig>();
@@ -30,7 +30,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
 
             Assert.True(completed);
 
-            return foundIssues.Where(i => i.relativePath.Equals(tempAsset.relativePath));
+            return foundIssues.Where(i => i.relativePath.Equals(tempAsset.relativePath)).ToArray();
         }
     }
 }

--- a/Tests/Editor/ScriptIssueTests.cs
+++ b/Tests/Editor/ScriptIssueTests.cs
@@ -21,6 +21,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
         TempAsset m_TempAssetIssueInNestedClass;
         TempAsset m_TempAssetIssueInOverrideMethod;
         TempAsset m_TempAssetIssueInVirtualMethod;
+        TempAsset m_TempAssetAnyApiInNamespace;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -184,6 +185,18 @@ class ClassWithDelegate
     }
 }
 ");
+
+            m_TempAssetAnyApiInNamespace = new TempAsset("AnyApiInNamespace.cs", @"
+using System.Linq;
+using System.Collections.Generic;
+class AnyApiInNamespace
+{
+    int SumAllValues(List<int> list)
+    {
+        return list.Sum();
+    }
+}
+");
         }
 
         [OneTimeTearDown]
@@ -332,6 +345,16 @@ class ClassWithDelegate
             Assert.NotNull(issue);
 
             Assert.True(issue.callingMethod.Equals("System.Int32 ClassWithDelegate/<>c::<Dummy>b__1_0()"));
+        }
+
+        [Test]
+        public void IssueInNamespaceIsFound()
+        {
+            var allScriptIssues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetAnyApiInNamespace);
+            var issue = allScriptIssues.FirstOrDefault(i => i.description.Equals("Enumerable.Sum"));
+            Assert.NotNull(issue);
+
+            Assert.True(issue.descriptor.description.Equals("System.Linq.*"));
         }
     }
 }

--- a/Tests/Editor/ScriptIssueTests.cs
+++ b/Tests/Editor/ScriptIssueTests.cs
@@ -10,6 +10,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
     class ScriptIssueTests
     {
         TempAsset m_TempAsset;
+        TempAsset m_TempAssetDerivedClassMethod;
         TempAsset m_TempAssetInPlugin;
         TempAsset m_TempAssetInEditorCode;
         TempAsset m_TempAssetInPlayerCode;
@@ -32,6 +33,17 @@ class MyClass
     {
         // Accessing Camera.main property is not recommended and will be reported as a possible performance problem.
         Debug.Log(Camera.main.name);
+    }
+}
+");
+
+            m_TempAssetDerivedClassMethod = new TempAsset("DerivedClassMethod.cs", @"
+using UnityEngine;
+class DerivedClassMethod
+{
+    bool IsMainCamera(Camera camera)
+    {
+        return camera.tag == ""MainCamera"";
     }
 }
 ");
@@ -207,6 +219,20 @@ class ClassWithDelegate
             // check custom property
             Assert.AreEqual((int)CodeProperty.Num, myIssue.GetNumCustomProperties());
             Assert.True(myIssue.GetCustomProperty((int)CodeProperty.Assembly).Equals(AssemblyHelper.DefaultAssemblyName));
+        }
+
+        [Test]
+        public void DerivedClassMethodIssueIsFound()
+        {
+            var filteredIssues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetDerivedClassMethod);
+
+            Assert.AreEqual(1, filteredIssues.Count());
+
+            var myIssue = filteredIssues.FirstOrDefault();
+
+            Assert.NotNull(myIssue);
+            Assert.NotNull(myIssue.descriptor);
+            Assert.True(myIssue.description.Equals("UnityEngine.Component.tag"));
         }
 
         [Test]


### PR DESCRIPTION
Project Auditor fails to detect calls to a Component (or derived type) _.tag_  property. This is due to two problems:
- _Component.tag_ signature is not in the database of api calls
- Calling _.tag_ on a Component derived type, such as _Camera_, fails to be detected because only the base type is checked

This PR solves thee above problems.

cc @unitystevem 