### PR TITLE
Add zoom support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Added zoom slider
+
 ## [0.4.2-preview] - 2021-02-01
 * Fixed detection of API calls using a derived type
 * Fixed reporting of *Editor Default Resources* shaders

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -192,22 +192,29 @@ namespace Unity.ProjectAuditor.Editor.UI
         void DrawTable(ProjectIssue[] selectedIssues)
         {
             EditorGUILayout.BeginVertical();
+            EditorGUILayout.Space();
+
+            EditorGUILayout.BeginHorizontal();
+            if (m_Desc.groupByDescription)
+            {
+                if (GUILayout.Button(Styles.CollapseAllButton, EditorStyles.toolbarButton, GUILayout.ExpandWidth(true), GUILayout.Width(100)))
+                    SetRowsExpanded(false);
+                if (GUILayout.Button(Styles.ExpandAllButton, EditorStyles.toolbarButton, GUILayout.ExpandWidth(true), GUILayout.Width(100)))
+                    SetRowsExpanded(true);
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Zoom: ", EditorStyles.toolbarButton, GUILayout.ExpandWidth(false), GUILayout.Width(80));
+            m_Preferences.fontSize = (int)GUILayout.HorizontalSlider(m_Preferences.fontSize, Preferences.k_MinFontSize, Preferences.k_MaxFontSize, GUILayout.ExpandWidth(false), GUILayout.Width(100));
+            m_Table.SetFontSize(m_Preferences.fontSize);
+
+            EditorGUILayout.EndHorizontal();
 
             var r = EditorGUILayout.GetControlRect(GUILayout.ExpandHeight(true));
 
             Profiler.BeginSample("IssueTable.OnGUI");
             m_Table.OnGUI(r);
             Profiler.EndSample();
-
-            if (m_Desc.groupByDescription)
-            {
-                EditorGUILayout.BeginHorizontal();
-                if (GUILayout.Button(Styles.CollapseAllButton, GUILayout.ExpandWidth(true), GUILayout.Width(100)))
-                    SetRowsExpanded(false);
-                if (GUILayout.Button(Styles.ExpandAllButton, GUILayout.ExpandWidth(true), GUILayout.Width(100)))
-                    SetRowsExpanded(true);
-                EditorGUILayout.EndHorizontal();
-            }
 
             var info = selectedIssues.Length + " / " + m_Table.GetNumMatchingIssues() + " Items";
             EditorGUILayout.LabelField(info, GUILayout.ExpandWidth(true), GUILayout.Width(200));
@@ -235,14 +242,19 @@ namespace Unity.ProjectAuditor.Editor.UI
             m_Preferences.details = BoldFoldout(m_Preferences.details, Styles.DetailsFoldout);
             if (m_Preferences.details)
             {
+                var textAreaStyle = new GUIStyle(EditorStyles.textArea)
+                {
+                    fontSize = m_Preferences.fontSize
+                };
+
                 if (problemDescriptor != null)
                 {
                     EditorStyles.textField.wordWrap = true;
-                    GUILayout.TextArea(problemDescriptor.problem, GUILayout.MaxHeight(LayoutSize.FoldoutMaxHeight));
+                    GUILayout.TextArea(problemDescriptor.problem, textAreaStyle, GUILayout.MaxHeight(LayoutSize.FoldoutMaxHeight));
                 }
                 else
                 {
-                    EditorGUILayout.LabelField(k_NoIssueSelectedText);
+                    EditorGUILayout.LabelField(k_NoIssueSelectedText, textAreaStyle);
                 }
             }
 
@@ -256,14 +268,18 @@ namespace Unity.ProjectAuditor.Editor.UI
             m_Preferences.recommendation = BoldFoldout(m_Preferences.recommendation, Styles.RecommendationFoldout);
             if (m_Preferences.recommendation)
             {
+                var textAreaStyle = new GUIStyle(EditorStyles.textArea)
+                {
+                    fontSize = m_Preferences.fontSize
+                };
+
                 if (problemDescriptor != null)
                 {
-                    EditorStyles.textField.wordWrap = true;
-                    GUILayout.TextArea(problemDescriptor.solution, GUILayout.MaxHeight(LayoutSize.FoldoutMaxHeight));
+                    GUILayout.TextArea(problemDescriptor.solution, textAreaStyle, GUILayout.MaxHeight(LayoutSize.FoldoutMaxHeight));
                 }
                 else
                 {
-                    EditorGUILayout.LabelField(k_NoIssueSelectedText);
+                    EditorGUILayout.LabelField(k_NoIssueSelectedText, textAreaStyle);
                 }
             }
 

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -204,8 +204,8 @@ namespace Unity.ProjectAuditor.Editor.UI
             }
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Zoom: ", EditorStyles.toolbarButton, GUILayout.ExpandWidth(false), GUILayout.Width(80));
-            m_Preferences.fontSize = (int)GUILayout.HorizontalSlider(m_Preferences.fontSize, Preferences.k_MinFontSize, Preferences.k_MaxFontSize, GUILayout.ExpandWidth(false), GUILayout.Width(100));
+            EditorGUILayout.LabelField("Zoom", EditorStyles.label, GUILayout.ExpandWidth(false), GUILayout.Width(40));
+            m_Preferences.fontSize = (int)GUILayout.HorizontalSlider(m_Preferences.fontSize, Preferences.k_MinFontSize, Preferences.k_MaxFontSize, GUILayout.ExpandWidth(false), GUILayout.Width(80));
             m_Table.SetFontSize(m_Preferences.fontSize);
 
             EditorGUILayout.EndHorizontal();

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -38,6 +38,8 @@ namespace Unity.ProjectAuditor.Editor.UI
         int m_NextId;
         int m_NumMatchingIssues;
         bool m_FlatView;
+        int m_FontSize;
+        float m_SingleLineHeight;
 
         public IssueTable(TreeViewState state, MultiColumnHeader multicolumnHeader,
                           AnalysisViewDescriptor desc, ProjectAuditorConfig config,
@@ -49,6 +51,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             m_Desc = desc;
             m_FlatView = !desc.groupByDescription;
             m_NextId = k_FirstId;
+            m_FontSize = Preferences.k_MinFontSize;
             multicolumnHeader.sortingChanged += OnSortingChanged;
         }
 
@@ -191,6 +194,14 @@ namespace Unity.ProjectAuditor.Editor.UI
             return base.GetDescendantsThatHaveChildren(id);
         }
 
+        public void SetFontSize(int fontSize)
+        {
+            const int k_DefaultRowHeight = 18;
+
+            m_FontSize = fontSize;
+            rowHeight = k_DefaultRowHeight * fontSize / Preferences.k_MinFontSize;
+        }
+
         protected override void RowGUI(RowGUIArgs args)
         {
             for (var i = 0; i < args.GetNumVisibleColumns(); ++i)
@@ -209,11 +220,16 @@ namespace Unity.ProjectAuditor.Editor.UI
                 CenterRectUsingSingleLineHeight(ref cellRect);
             }
 
+            var labelStyle = new GUIStyle(EditorStyles.label)
+            {
+                fontSize = m_FontSize
+            };
+
             var item = treeViewItem as IssueTableItem;
             if (item == null)
             {
                 if (column == ColumnType.Description)
-                    EditorGUI.LabelField(cellRect, new GUIContent(treeViewItem.displayName, treeViewItem.displayName));
+                    EditorGUI.LabelField(cellRect, new GUIContent(treeViewItem.displayName, treeViewItem.displayName), labelStyle);
                 return;
             }
 
@@ -227,14 +243,15 @@ namespace Unity.ProjectAuditor.Editor.UI
                 rule = m_Config.GetRule(descriptor);
             if (rule != null && rule.severity == Rule.Severity.None) GUI.enabled = false;
 
+
             if (item.IsGroup())
                 switch (column)
                 {
                     case ColumnType.Description:
-                        EditorGUI.LabelField(cellRect, new GUIContent(item.GetDisplayName(), item.GetDisplayName()));
+                        EditorGUI.LabelField(cellRect, new GUIContent(item.GetDisplayName(), item.GetDisplayName()), labelStyle);
                         break;
                     case ColumnType.Area:
-                        EditorGUI.LabelField(cellRect, new GUIContent(descriptor.area, areaLongDescription));
+                        EditorGUI.LabelField(cellRect, new GUIContent(descriptor.area, areaLongDescription), labelStyle);
                         break;
                 }
             else
@@ -274,16 +291,16 @@ namespace Unity.ProjectAuditor.Editor.UI
                         if (!string.IsNullOrEmpty(iconName))
                         {
 #if UNITY_2018_3_OR_NEWER
-                            EditorGUI.LabelField(cellRect, EditorGUIUtility.TrIconContent(iconName, tooltip));
+                            EditorGUI.LabelField(cellRect, EditorGUIUtility.TrIconContent(iconName, tooltip), labelStyle);
 #else
-                            EditorGUI.LabelField(cellRect, new GUIContent(EditorGUIUtility.FindTexture(iconName), tooltip));
+                            EditorGUI.LabelField(cellRect, new GUIContent(EditorGUIUtility.FindTexture(iconName), tooltip), labelStyle);
 #endif
                         }
                     }
                     break;
                     case ColumnType.Area:
                         if (!m_Desc.groupByDescription)
-                            EditorGUI.LabelField(cellRect, new GUIContent(descriptor.area, areaLongDescription));
+                            EditorGUI.LabelField(cellRect, new GUIContent(descriptor.area, areaLongDescription), labelStyle);
                         break;
                     case ColumnType.Description:
                         if (m_Desc.groupByDescription)
@@ -299,21 +316,21 @@ namespace Unity.ProjectAuditor.Editor.UI
                                 guiContent = EditorGUIUtility.TrTextContentWithIcon(text, tooltip, icon);
                             }
 #endif
-                            EditorGUI.LabelField(cellRect, guiContent);
+                            EditorGUI.LabelField(cellRect, guiContent, labelStyle);
                         }
                         else if (string.IsNullOrEmpty(descriptor.problem))
                         {
                             if (issue.location != null)
                             {
                                 EditorGUI.LabelField(cellRect,
-                                    new GUIContent(item.GetDisplayName(), issue.location.Path));
+                                    new GUIContent(item.GetDisplayName(), issue.location.Path), labelStyle);
                             }
                             else
-                                EditorGUI.LabelField(cellRect, item.GetDisplayName());
+                                EditorGUI.LabelField(cellRect, item.GetDisplayName(), labelStyle);
                         }
                         else
                         {
-                            EditorGUI.LabelField(cellRect, new GUIContent(item.GetDisplayName(), descriptor.problem));
+                            EditorGUI.LabelField(cellRect, new GUIContent(item.GetDisplayName(), descriptor.problem), labelStyle);
                         }
 
                         break;
@@ -325,7 +342,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                                 filename += string.Format(":{0}", issue.line);
 
                             // display fullpath as tooltip
-                            EditorGUI.LabelField(cellRect, new GUIContent(filename, issue.relativePath));
+                            EditorGUI.LabelField(cellRect, new GUIContent(filename, issue.relativePath), labelStyle);
                         }
                         break;
 
@@ -336,7 +353,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                             if (issue.category == IssueCategory.Code)
                                 path += string.Format(":{0}", issue.line);
 
-                            EditorGUI.LabelField(cellRect, new GUIContent(path));
+                            EditorGUI.LabelField(cellRect, new GUIContent(path), labelStyle);
                         }
                         break;
 
@@ -346,7 +363,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                             var ext = issue.location.Extension;
                             if (ext.StartsWith("."))
                                 ext = ext.Substring(1);
-                            EditorGUI.LabelField(cellRect, new GUIContent(ext));
+                            EditorGUI.LabelField(cellRect, new GUIContent(ext), labelStyle);
                         }
 
                         break;
@@ -359,13 +376,23 @@ namespace Unity.ProjectAuditor.Editor.UI
                             if (desc.Format == PropertyFormat.Bool)
                                 EditorGUI.Toggle(cellRect, property.Equals(true.ToString()));
                             else
-                                EditorGUI.LabelField(cellRect, new GUIContent(property));
+                                EditorGUI.LabelField(cellRect, new GUIContent(property), labelStyle);
                         }
 
                         break;
                 }
 
             if (rule != null && rule.severity == Rule.Severity.None) GUI.enabled = true;
+        }
+
+        void CenterRectUsingSingleLineHeight(ref Rect rect)
+        {
+            float singleLineHeight = rowHeight;
+            if (rect.height > singleLineHeight)
+            {
+                rect.y += (rect.height - singleLineHeight) * 0.5f;
+                rect.height = singleLineHeight;
+            }
         }
 
         protected override void DoubleClickedItem(int id)

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -384,7 +384,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             if (rule != null && rule.severity == Rule.Severity.None) GUI.enabled = true;
         }
 
-        void CenterRectUsingSingleLineHeight(ref Rect rect)
+        new void CenterRectUsingSingleLineHeight(ref Rect rect)
         {
             float singleLineHeight = rowHeight;
             if (rect.height > singleLineHeight)

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -39,7 +39,6 @@ namespace Unity.ProjectAuditor.Editor.UI
         int m_NumMatchingIssues;
         bool m_FlatView;
         int m_FontSize;
-        float m_SingleLineHeight;
 
         public IssueTable(TreeViewState state, MultiColumnHeader multicolumnHeader,
                           AnalysisViewDescriptor desc, ProjectAuditorConfig config,

--- a/Editor/UI/Preferences.cs
+++ b/Editor/UI/Preferences.cs
@@ -5,6 +5,9 @@ namespace Unity.ProjectAuditor.Editor.UI
     [Serializable]
     class Preferences
     {
+        public const int k_MinFontSize = 12;
+        public const int k_MaxFontSize = 22;
+
         // foldout preferences
         public bool filters = true;
         public bool actions = true;
@@ -16,5 +19,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         public bool onlyCriticalIssues;
         public bool mutedIssues;
         public bool emptyGroups;
+
+        public int fontSize = k_MinFontSize;
     }
 }


### PR DESCRIPTION
**Problem**
Project Auditor often reports a lot of issues and depending on the screen resolution it might be tricky to read through the list and the issue details/recommendation.

**Solution**
With this PR, the user can easily adjust the font size via a zoom slider. Note that this is a user preference so it will not be saved in the Project Auditor asset in the project.

This video shows how it works: https://user-images.githubusercontent.com/12098182/106491599-f0aeb280-64ae-11eb-9ea2-5ffe06b06260.mp4

By no means this is the perfect solution, so let me know if you have alternative ideas.