### PR TITLE
Replace 'tabs' with dropdown selection

### DIFF
--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -29,6 +29,7 @@ namespace Unity.ProjectAuditor.Editor.UI
     {
         public IssueCategory category;
         public string name;
+        public int menuOrder;
         public bool groupByDescription;
         public bool descriptionWithIcon;
         public bool showAreaSelection;

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -585,7 +585,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         void OnViewChanged(object userData)
         {
-            var index = (int) userData;
+            var index = (int)userData;
             var activeTabChanged = (m_ActiveViewIndex != index);
             if (activeTabChanged)
             {
@@ -1004,7 +1004,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         void DrawToolbar()
         {
-            GUILayout.BeginHorizontal(EditorStyles.toolbar);
+            EditorGUILayout.BeginHorizontal(EditorStyles.toolbar);
             {
                 GUI.enabled = (m_AnalysisState == AnalysisState.Valid || m_AnalysisState == AnalysisState.NotStarted);
 
@@ -1165,9 +1165,6 @@ namespace Unity.ProjectAuditor.Editor.UI
 
             public static readonly GUIContent AnalyzeButton =
                 new GUIContent("Analyze", "Analyze Project and list all issues found.");
-
-            public static readonly GUIContent ViewDropdown =
-                new GUIContent("Active View", "Select view.");
 
             public static readonly GUIContent AnalysisInProgressLabel =
                 new GUIContent("Analysis in progress...", "Analysis in progress...please wait.");

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -32,12 +32,13 @@ namespace Unity.ProjectAuditor.Editor.UI
         static readonly string[] AreaNames = Enum.GetNames(typeof(Area));
         static ProjectAuditorWindow Instance;
 
-        readonly AnalysisViewDescriptor[] m_AnalysisViewDescriptors =
+        AnalysisViewDescriptor[] m_AnalysisViewDescriptors =
         {
             new AnalysisViewDescriptor
             {
                 category = IssueCategory.Assets,
                 name = "Assets",
+                menuOrder = 3,
                 groupByDescription = true,
                 descriptionWithIcon = true,
                 showAreaSelection = false,
@@ -67,6 +68,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 category = IssueCategory.Shaders,
                 name = "Shaders",
+                menuOrder = 2,
                 groupByDescription = false,
                 descriptionWithIcon = true,
                 showAreaSelection = false,
@@ -145,6 +147,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 category = IssueCategory.Code,
                 name = "Code",
+                menuOrder = 0,
                 groupByDescription = true,
                 descriptionWithIcon = false,
                 showAreaSelection = true,
@@ -180,6 +183,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 category = IssueCategory.ProjectSettings,
                 name = "Settings",
+                menuOrder = 1,
                 groupByDescription = false,
                 descriptionWithIcon = false,
                 showAreaSelection = true,
@@ -378,6 +382,8 @@ namespace Unity.ProjectAuditor.Editor.UI
                     m_AreaSelection.SetAll(AreaNames);
                 }
             }
+
+            Array.Sort(m_AnalysisViewDescriptors, (a, b) => a.menuOrder.CompareTo(b.menuOrder));
 
             m_ViewNames = m_AnalysisViewDescriptors.Select(m => m.name).ToArray();
             m_ViewContents = m_AnalysisViewDescriptors.Select(m => new GUIContent("View: " + m.name)).ToArray();
@@ -586,8 +592,8 @@ namespace Unity.ProjectAuditor.Editor.UI
         void OnViewChanged(object userData)
         {
             var index = (int)userData;
-            var activeTabChanged = (m_ActiveViewIndex != index);
-            if (activeTabChanged)
+            var activeViewChanged = (m_ActiveViewIndex != index);
+            if (activeViewChanged)
             {
                 var analytic = ProjectAuditorAnalytics.BeginAnalytic();
                 m_ActiveViewIndex = index;
@@ -1017,7 +1023,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                 GUI.enabled = m_AnalysisState == AnalysisState.Valid;
 
                 Utility.ToolbarDropdownList(m_ViewContents[m_ActiveViewIndex], m_ViewNames,
-                    m_ViewNames[m_ActiveViewIndex],
+                    m_ActiveViewIndex,
                     OnViewChanged, GUILayout.Width(buttonWidth));
 
                 if (Utility.ToolbarButtonWithDropdownList(Styles.ExportButton, Styles.ExportModeStrings,

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -179,7 +179,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             new AnalysisViewDescriptor
             {
                 category = IssueCategory.ProjectSettings,
-                name = "Project Settings",
+                name = "Settings",
                 groupByDescription = false,
                 descriptionWithIcon = false,
                 showAreaSelection = true,
@@ -380,7 +380,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             }
 
             m_ViewNames = m_AnalysisViewDescriptors.Select(m => m.name).ToArray();
-            m_ViewContents = m_AnalysisViewDescriptors.Select(m => new GUIContent(m.name)).ToArray();
+            m_ViewContents = m_AnalysisViewDescriptors.Select(m => new GUIContent("View: " + m.name)).ToArray();
 
             if (m_TextFilter == null)
                 m_TextFilter = new TextFilter();
@@ -1008,7 +1008,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 GUI.enabled = (m_AnalysisState == AnalysisState.Valid || m_AnalysisState == AnalysisState.NotStarted);
 
-                const int buttonWidth = 110;
+                const int buttonWidth = 80;
                 if (GUILayout.Button(Styles.AnalyzeButton, EditorStyles.toolbarButton, GUILayout.Width(buttonWidth)))
                 {
                     Analyze();
@@ -1016,13 +1016,11 @@ namespace Unity.ProjectAuditor.Editor.UI
 
                 GUI.enabled = m_AnalysisState == AnalysisState.Valid;
 
-                if (Utility.ButtonWithDropdownList(m_ViewContents[m_ActiveViewIndex], m_ViewNames, m_ViewNames[m_ActiveViewIndex],
-                    OnViewChanged, GUILayout.Width(buttonWidth)))
-                {
-                    GUIUtility.ExitGUI();
-                }
+                Utility.ToolbarDropdownList(m_ViewContents[m_ActiveViewIndex], m_ViewNames,
+                    m_ViewNames[m_ActiveViewIndex],
+                    OnViewChanged, GUILayout.Width(buttonWidth));
 
-                if (Utility.ButtonWithDropdownList(Styles.ExportButton, Styles.ExportModeStrings, string.Empty,
+                if (Utility.ToolbarButtonWithDropdownList(Styles.ExportButton, Styles.ExportModeStrings,
                     OnExport, GUILayout.Width(buttonWidth)))
                 {
                     Export();

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1008,7 +1008,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 GUI.enabled = (m_AnalysisState == AnalysisState.Valid || m_AnalysisState == AnalysisState.NotStarted);
 
-                const int buttonWidth = 80;
+                const int buttonWidth = 100;
                 if (GUILayout.Button(Styles.AnalyzeButton, EditorStyles.toolbarButton, GUILayout.Width(buttonWidth)))
                 {
                     Analyze();
@@ -1032,7 +1032,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
                 if (m_DeveloperMode)
                 {
-                    if (GUILayout.Button(Styles.ReloadButton, EditorStyles.toolbarButton, GUILayout.ExpandWidth(true), GUILayout.Width(80)))
+                    if (GUILayout.Button(Styles.ReloadButton, EditorStyles.toolbarButton, GUILayout.ExpandWidth(true), GUILayout.Width(buttonWidth)))
                     {
                         Reload();
                     }

--- a/Editor/UI/Utility.cs
+++ b/Editor/UI/Utility.cs
@@ -8,21 +8,7 @@ namespace Unity.ProjectAuditor.Editor.UI
     {
         static class Styles
         {
-            public static GUIStyle ToolbarButton;
             public static GUIStyle Foldout;
-        }
-
-        static GUIStyle GetStyle(string styleName)
-        {
-            GUIStyle s = UnityEngine.GUI.skin.FindStyle(styleName);
-            if (s == null)
-                s = EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector).FindStyle(styleName);
-            if (s == null)
-            {
-                Debug.LogError("Missing built-in guistyle " + styleName);
-                s = new GUIStyle();
-            }
-            return s;
         }
 
         internal static bool BoldFoldout(bool toggle, GUIContent content)
@@ -39,10 +25,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         internal static void ToolbarDropdownList(GUIContent content, string[] buttonNames, string activeSelection, GenericMenu.MenuFunction2 callback, params GUILayoutOption[] options)
         {
-            if (Styles.ToolbarButton == null)
-                Styles.ToolbarButton = GetStyle("ToolbarButton");
-
-            var r = GUILayoutUtility.GetRect(content, Styles.ToolbarButton, GUILayout.Width(115f));
+            var r = GUILayoutUtility.GetRect(content, EditorStyles.toolbarButton, GUILayout.Width(115f));
             if (EditorGUI.DropdownButton(r, content, FocusType.Passive, EditorStyles.toolbarDropDown))
             {
                 var menu = new GenericMenu();

--- a/Editor/UI/Utility.cs
+++ b/Editor/UI/Utility.cs
@@ -23,7 +23,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             return EditorGUILayout.Foldout(toggle, content, Styles.Foldout);
         }
 
-        internal static void ToolbarDropdownList(GUIContent content, string[] buttonNames, string activeSelection, GenericMenu.MenuFunction2 callback, params GUILayoutOption[] options)
+        internal static void ToolbarDropdownList(GUIContent content, string[] buttonNames, int activeSelection, GenericMenu.MenuFunction2 callback, params GUILayoutOption[] options)
         {
             var r = GUILayoutUtility.GetRect(content, EditorStyles.toolbarButton, options);
             if (EditorGUI.DropdownButton(r, content, FocusType.Passive, EditorStyles.toolbarDropDown))
@@ -31,7 +31,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                 var menu = new GenericMenu();
 
                 for (var i = 0; i != buttonNames.Length; i++)
-                    menu.AddItem(new GUIContent(buttonNames[i]), buttonNames[i] == activeSelection, callback, i);
+                    menu.AddItem(new GUIContent(buttonNames[i]), i == activeSelection, callback, i);
                 menu.DropDown(r);
             }
         }

--- a/Editor/UI/Utility.cs
+++ b/Editor/UI/Utility.cs
@@ -25,7 +25,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         internal static void ToolbarDropdownList(GUIContent content, string[] buttonNames, string activeSelection, GenericMenu.MenuFunction2 callback, params GUILayoutOption[] options)
         {
-            var r = GUILayoutUtility.GetRect(content, EditorStyles.toolbarButton, GUILayout.Width(115f));
+            var r = GUILayoutUtility.GetRect(content, EditorStyles.toolbarButton, options);
             if (EditorGUI.DropdownButton(r, content, FocusType.Passive, EditorStyles.toolbarDropDown))
             {
                 var menu = new GenericMenu();

--- a/Editor/UI/Utility.cs
+++ b/Editor/UI/Utility.cs
@@ -24,12 +24,9 @@ namespace Unity.ProjectAuditor.Editor.UI
             return EditorGUILayout.Foldout(toggle, content, Styles.Foldout);
         }
 
-        internal static bool ButtonWithDropdownList(GUIContent content, string[] buttonNames, GenericMenu.MenuFunction2 callback, params GUILayoutOption[] options)
+        internal static bool ButtonWithDropdownList(GUIContent content, string[] buttonNames, string selection, GenericMenu.MenuFunction2 callback, params GUILayoutOption[] options)
         {
-            if (Styles.DropDownButton == null)
-                Styles.DropDownButton = GUI.skin.FindStyle("DropDownButton");
-
-            var rect = GUILayoutUtility.GetRect(content, Styles.DropDownButton, options);
+            var rect = GUILayoutUtility.GetRect(content, EditorStyles.toolbarDropDown, options);
             var dropDownRect = rect;
 
             const float kDropDownButtonWidth = 20f;
@@ -39,7 +36,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             {
                 var menu = new GenericMenu();
                 for (var i = 0; i != buttonNames.Length; i++)
-                    menu.AddItem(new GUIContent(buttonNames[i]), false, callback, i);
+                    menu.AddItem(new GUIContent(buttonNames[i]), buttonNames[i].Equals(selection), callback, i);
 
                 menu.DropDown(rect);
                 Event.current.Use();
@@ -47,7 +44,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                 return false;
             }
 
-            return GUI.Button(rect, content, Styles.DropDownButton);
+            return GUI.Button(rect, content, EditorStyles.toolbarDropDown);
         }
 
         internal static void DrawSelectedText(string text)


### PR DESCRIPTION
**Problem**
The current _tab-like_ solution for selecting the active analysis is not scalable.

**Solution**
Replace it with a dropdown in the toolbar. This will allow us to add more views in the future such as for Allocations, Generics, Scenes, etc...
<img width="621" alt="view-dropdown" src="https://user-images.githubusercontent.com/12098182/108397494-ef4fea80-720f-11eb-83ae-42b0a6ba4081.png">
