### PR TITLE
fix logWhenShaderIsCompiled on early 2018.4.x versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 * Fixed Android player.log parsing
+* Fixed *GraphicsSettings.logWhenShaderIsCompiled* compilation error on early 2018.4.x releases 
 * Added descriptor's minimum/maximum version
 * Added zoom slider
 * Reduced UI managed allocations

--- a/Editor/UI/ShaderVariantsWindow.cs
+++ b/Editor/UI/ShaderVariantsWindow.cs
@@ -2,9 +2,9 @@ using System;
 using System.IO;
 using System.Linq;
 using Unity.ProjectAuditor.Editor.Auditors;
+using Unity.ProjectAuditor.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace Unity.ProjectAuditor.Editor.UI
 {
@@ -48,15 +48,15 @@ To find which shader variants are compiled at runtime, follow these steps:
                 EditorUtility.DisplayDialog("Shader Variants", k_PlayerLogProcessed, "Ok");
                 m_AnalysisView.Refresh();
             }
-            else
+            else if (GraphicsSettingsHelper.logShaderCompilationSupported)
             {
-                if (GraphicsSettings.logWhenShaderIsCompiled)
+                if (GraphicsSettingsHelper.logWhenShaderIsCompiled)
                 {
                     EditorUtility.DisplayDialog("Shader Variants", k_NoCompiledVariantWarning, "Ok");
                 }
                 else
                 {
-                    GraphicsSettings.logWhenShaderIsCompiled = EditorUtility.DisplayDialog("Shader Variants", k_NoCompiledVariantWarningLogDisabled, "Yes", "No");
+                    GraphicsSettingsHelper.logWhenShaderIsCompiled = EditorUtility.DisplayDialog("Shader Variants", k_NoCompiledVariantWarningLogDisabled, "Yes", "No");
                 }
             }
         }

--- a/Editor/Utils/GraphicsSettingsHelper.cs
+++ b/Editor/Utils/GraphicsSettingsHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine.Rendering;
+
+namespace Unity.ProjectAuditor.Editor.Utils
+{
+    internal static class GraphicsSettingsHelper
+    {
+        static PropertyInfo s_LogWhenShaderIsCompiled;
+
+        public static bool logShaderCompilationSupported
+        {
+            get
+            {
+                return s_LogWhenShaderIsCompiled != null;
+            }
+        }
+
+        public static bool logWhenShaderIsCompiled
+        {
+            get
+            {
+                if (s_LogWhenShaderIsCompiled == null)
+                    return false;
+                return (bool)s_LogWhenShaderIsCompiled.GetValue(null, null);
+            }
+
+            set
+            {
+                if (s_LogWhenShaderIsCompiled == null)
+                    return;
+                s_LogWhenShaderIsCompiled.SetValue(null, value, null);
+            }
+        }
+
+        [InitializeOnLoadMethod]
+        static void Initialize()
+        {
+            var graphicsSettings = typeof(GraphicsSettings);
+            s_LogWhenShaderIsCompiled = graphicsSettings.GetProperty("logWhenShaderIsCompiled", BindingFlags.Static | BindingFlags.Public);
+        }
+    }
+}

--- a/Editor/Utils/GraphicsSettingsHelper.cs.meta
+++ b/Editor/Utils/GraphicsSettingsHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1d87f388c85c4a1a95ae9ba49ae1ceaf
+timeCreated: 1614100625


### PR DESCRIPTION
**Problem**
Project Auditor relies on [_GraphicsSettings.logWhenShaderIsCompiled_](https://docs.unity3d.com/ScriptReference/Rendering.GraphicsSettings-logWhenShaderIsCompiled.html). Unfortunately, this is not available in a few of the early 2018.4.x releases which causes a couple of compilation errors.

**Solution**
With this PR, Project Auditor does not use _GraphicsSettings.logWhenShaderIsCompiled_ directly anymore. Instead it uses reflection. By doing this, it's only used if available.