### PR TITLE
Report an issue if the splash screen is enabled and can be disabled

### DIFF
--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -292,9 +292,9 @@
           "solution": "When this option is enabled, only a single instance of the Collision type is created and reused for each individual callback. This reduces waste for the garbage collector to handle and improves performance."
         },
         {
-          "id": 201030,
+          "id": 201029,
           "description": "Player: Splash Screen",
-          "type": "UnityEngine.PlayerSettings.SplashScreen.show",
+          "type": "UnityEngine.PlayerSettings.SplashScreen",
           "method": "show",
           "customevaluator": "PlayerSettingsSplashScreenIsEnabledAndCanBeDisabled",
           "area": "LoadTimes",

--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -294,7 +294,7 @@
         {
           "id": 201029,
           "description": "Player: Splash Screen",
-          "type": "UnityEngine.PlayerSettings.SplashScreen",
+          "type": "UnityEditor.PlayerSettings.SplashScreen",
           "method": "show",
           "customevaluator": "PlayerSettingsSplashScreenIsEnabledAndCanBeDisabled",
           "area": "LoadTimes",

--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -290,6 +290,16 @@
           "area": "Memory",
           "problem": "The \"Reuse Collision Callbacks\" option in Physics Settings is disabled. For each OnCollision* callback, a temporary managed object is allocated which, eventually, will need to be garbage collected.",
           "solution": "When this option is enabled, only a single instance of the Collision type is created and reused for each individual callback. This reduces waste for the garbage collector to handle and improves performance."
+        },
+        {
+          "id": 201030,
+          "description": "Player: Splash Screen Enabled",
+          "type": "UnityEngine.PlayerSettings.SplashScreen.show",
+          "method": "show",
+          "customevaluator": "PlayerSettingsSplashScreenIsEnabledAndCanBeDisabled",
+          "area": "LoadTimes",
+          "problem": "Splash Screen is enabled and will increase the time it take to load into the first scene.",
+          "solution": "Disable the Splash Screen option in Player Settings."
         }
     ]
 }

--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -293,12 +293,12 @@
         },
         {
           "id": 201030,
-          "description": "Player: Splash Screen Enabled",
+          "description": "Player: Splash Screen",
           "type": "UnityEngine.PlayerSettings.SplashScreen.show",
           "method": "show",
           "customevaluator": "PlayerSettingsSplashScreenIsEnabledAndCanBeDisabled",
           "area": "LoadTimes",
-          "problem": "Splash Screen is enabled and will increase the time it take to load into the first scene.",
+          "problem": "Splash Screen is enabled and will increase the time it takes to load into the first scene.",
           "solution": "Disable the Splash Screen option in Player Settings."
         }
     ]

--- a/Editor/Auditors/SettingsAuditor.cs
+++ b/Editor/Auditors/SettingsAuditor.cs
@@ -37,8 +37,6 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.Physics", "Project/Physics"));
             m_ProjectSettingsMapping.Add(
                 new KeyValuePair<string, string>("UnityEngine.Physics2D", "Project/Physics 2D"));
-            m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.PlayerSettings",
-                "Project/Player"));
             m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.Time", "Project/Time"));
             m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.QualitySettings",
                 "Project/Quality"));

--- a/Editor/Auditors/SettingsAuditor.cs
+++ b/Editor/Auditors/SettingsAuditor.cs
@@ -37,6 +37,8 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.Physics", "Project/Physics"));
             m_ProjectSettingsMapping.Add(
                 new KeyValuePair<string, string>("UnityEngine.Physics2D", "Project/Physics 2D"));
+            m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.PlayerSettings",
+                "Project/Player"));
             m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.Time", "Project/Time"));
             m_ProjectSettingsMapping.Add(new KeyValuePair<string, string>("UnityEngine.QualitySettings",
                 "Project/Quality"));
@@ -100,7 +102,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         void AddIssue(ProblemDescriptor descriptor, string description, Action<ProjectIssue> onIssueFound)
         {
             var projectWindowPath = "";
-            var mappings = m_ProjectSettingsMapping.Where(p => p.Key.Contains(descriptor.type));
+            var mappings = m_ProjectSettingsMapping.Where(p => descriptor.type.StartsWith(p.Key));
             if (mappings.Count() > 0)
                 projectWindowPath = mappings.First().Value;
             onIssueFound(new ProjectIssue
@@ -148,8 +150,8 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             {
                 var helperType = m_Helpers.GetType();
                 var theMethod = helperType.GetMethod(descriptor.customevaluator);
-                var isIssue = (bool)theMethod.Invoke(m_Helpers, null);
-                if (isIssue) AddIssue(descriptor, descriptor.description, onIssueFound);
+                if((bool)theMethod.Invoke(m_Helpers, null))
+                    AddIssue(descriptor, descriptor.description, onIssueFound);
             }
         }
     }

--- a/Editor/SettingsAnalyzers/Evaluators.cs
+++ b/Editor/SettingsAnalyzers/Evaluators.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEditor.Rendering;
 using UnityEngine;
@@ -70,6 +71,20 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalyzers
 #else
             return false;
 #endif
+        }
+
+        public bool PlayerSettingsSplashScreenIsEnabledAndCanBeDisabled()
+        {
+            if (!PlayerSettings.SplashScreen.show)
+                return false;
+            var type = Type.GetType("UnityEditor.PlayerSettingsSplashScreenEditor,UnityEditor.dll");
+            if (type == null)
+                return false;
+
+            var licenseAllowsDisablingProperty = type.GetProperty("licenseAllowsDisabling", BindingFlags.Static | BindingFlags.NonPublic);
+            if (licenseAllowsDisablingProperty == null)
+               return false;
+            return (bool) licenseAllowsDisablingProperty.GetValue(null, null);
         }
 
         public bool PhysicsLayerCollisionMatrix()
@@ -211,5 +226,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalyzers
 
             return false;
         }
+
+
     }
 }

--- a/Tests/Editor/SettingIssueTests.cs
+++ b/Tests/Editor/SettingIssueTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
+using Unity.ProjectAuditor.Editor.SettingsAnalyzers;
 using UnityEngine;
 
 namespace UnityEditor.ProjectAuditor.EditorTests
@@ -39,6 +40,20 @@ namespace UnityEditor.ProjectAuditor.EditorTests
             Assert.NotNull(playerSettingIssue);
             Assert.True(playerSettingIssue.description.Equals("Player: Engine Code Stripping"));
             Assert.True(playerSettingIssue.location.Path.Equals("Project/Player"));
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void  SplashScreenIsEnabledAndCanBeDisabled(bool splashScreenEnabled)
+        {
+            var prevSplashScreenEnabled = PlayerSettings.SplashScreen.show;
+            PlayerSettings.SplashScreen.show = splashScreenEnabled;
+
+            var evaluators = new Evaluators();
+            Assert.AreEqual(splashScreenEnabled, evaluators.PlayerSettingsSplashScreenIsEnabledAndCanBeDisabled());
+
+            PlayerSettings.SplashScreen.show = prevSplashScreenEnabled;
         }
     }
 }


### PR DESCRIPTION
**Problem**
The Splash Screen can easily add 2+ seconds (depending on platform/project) to the total loading time into the first scene from launch. 

**Solution**
Report if the Splash Screen option is enabled when using paid-versions of Unity.


Note that the Unity Splash Screen cannot be disabled on free versions of Unity. It can, otherwise, be disabled.