### PR TITLE
Closure allocation improvements

### DIFF
--- a/Editor/Auditors/ScriptAuditor.cs
+++ b/Editor/Auditors/ScriptAuditor.cs
@@ -203,7 +203,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 }
 
                 Location location = null;
-                if (s != null)
+                if (s != null && !s.IsHidden)
                 {
                     location = new Location(AssemblyHelper.ResolveAssetPath(assemblyInfo, s.Document.Url), s.StartLine);
                     callerNode.location = location;

--- a/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
@@ -11,16 +11,26 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
         static readonly ProblemDescriptor k_ObjectAllocationDescriptor = new ProblemDescriptor
             (
             102002,
-            "Object Allocation (experimental)",
+            "Object Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
             "Try to avoid allocating objects in frequently-updated code."
             );
 
+        static readonly ProblemDescriptor k_ClosureAllocationDescriptor = new ProblemDescriptor
+        (
+            102003,
+            "Closure Allocation",
+            Area.Memory,
+            "An object is allocated in managed memory",
+            "Try to avoid allocating objects in frequently-updated code."
+        );
+
+
         static readonly ProblemDescriptor k_ArrayAllocationDescriptor = new ProblemDescriptor
             (
-            102003,
-            "Array Allocation (experimental)",
+            102004,
+            "Array Allocation",
             Area.Memory,
             "An array is allocated in managed memory",
             "Try to avoid allocating arrays in frequently-updated code."
@@ -29,6 +39,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
         public void Initialize(IAuditor auditor)
         {
             auditor.RegisterDescriptor(k_ObjectAllocationDescriptor);
+            auditor.RegisterDescriptor(k_ClosureAllocationDescriptor);
             auditor.RegisterDescriptor(k_ArrayAllocationDescriptor);
         }
 
@@ -41,30 +52,41 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 if (typeReference.IsValueType)
                     return null;
 
-                var descriptor = k_ObjectAllocationDescriptor;
-                var description = string.Format("'{0}' object allocation", typeReference.Name);
-
+                var typeName = typeReference.Name;
+                var isClosure = typeName.StartsWith("<>c__DisplayClass");
                 var calleeNode = new CallTreeNode(methodDefinition);
 
-                return new ProjectIssue
-                (
-                    descriptor,
-                    description,
-                    IssueCategory.Code,
-                    calleeNode
-                );
+                if (isClosure)
+                {
+                    return new ProjectIssue
+                    (
+                        k_ClosureAllocationDescriptor,
+                        string.Format("'{0}' closure allocation", typeReference.DeclaringType.FullName),
+                        IssueCategory.Code,
+                        calleeNode
+                    );
+                }
+                else
+                {
+                    return new ProjectIssue
+                    (
+                        k_ObjectAllocationDescriptor,
+                        string.Format("'{0}' object allocation", typeName),
+                        IssueCategory.Code,
+                        calleeNode
+                    );
+                }
             }
             else // OpCodes.Newarr
             {
                 var typeReference = (TypeReference)inst.Operand;
-                var descriptor = k_ArrayAllocationDescriptor;
                 var description = string.Format("'{0}' array allocation", typeReference.Name);
 
                 var calleeNode = new CallTreeNode(methodDefinition);
 
                 return new ProjectIssue
                 (
-                    descriptor,
+                    k_ArrayAllocationDescriptor,
                     description,
                     IssueCategory.Code,
                     calleeNode

--- a/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
@@ -52,10 +52,8 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 if (typeReference.IsValueType)
                     return null;
 
-                var typeName = typeReference.Name;
-                var isClosure = typeName.StartsWith("<>c__DisplayClass");
                 var calleeNode = new CallTreeNode(methodDefinition);
-
+                var isClosure = typeReference.Name.StartsWith("<>c__DisplayClass");
                 if (isClosure)
                 {
                     return new ProjectIssue
@@ -66,16 +64,14 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                         calleeNode
                     );
                 }
-                else
-                {
-                    return new ProjectIssue
-                    (
-                        k_ObjectAllocationDescriptor,
-                        string.Format("'{0}' object allocation", typeName),
-                        IssueCategory.Code,
-                        calleeNode
-                    );
-                }
+
+                return new ProjectIssue
+                (
+                    k_ObjectAllocationDescriptor,
+                    string.Format("'{0}' allocation", typeReference.FullName),
+                    IssueCategory.Code,
+                    calleeNode
+                );
             }
             else // OpCodes.Newarr
             {

--- a/Tests/Editor/AllocationTests.cs
+++ b/Tests/Editor/AllocationTests.cs
@@ -8,6 +8,7 @@ namespace UnityEditor.ProjectAuditor.EditorTests
     class AllocationTests
     {
         TempAsset m_TempAssetObjectAllocation;
+        TempAsset m_TempAssetClosureAllocation;
         TempAsset m_TempAssetArrayAllocation;
         TempAsset m_TempAssetMultidimensionalArrayAllocation;
         TempAsset m_TempAssetParamsArrayAllocation;
@@ -25,6 +26,20 @@ class ObjectAllocation
     }
 }
 ");
+
+            m_TempAssetClosureAllocation = new TempAsset("ClosureAllocation.cs", @"
+using UnityEngine;
+using System;
+class ClosureAllocation
+{
+    void Dummy()
+    {
+        int x = 1;
+        Func<int, int> f = y => y * x;
+    }
+}
+");
+
 
             m_TempAssetArrayAllocation = new TempAsset("ArrayAllocation.cs", @"
 class ArrayAllocation
@@ -79,11 +94,25 @@ class ParamsArrayAllocation
 
             Assert.AreEqual(1, issues.Count());
 
-            var allocationIssue = issues.FirstOrDefault();
+            var allocationIssue = issues.First();
 
-            Assert.NotNull(allocationIssue);
-            Assert.True(allocationIssue.description.Equals("'ObjectAllocation' object allocation"));
+            Assert.True(allocationIssue.description.Equals("'ObjectAllocation' allocation"));
             Assert.AreEqual(IssueCategory.Code, allocationIssue.category);
+        }
+
+        [Test]
+        public void ClosureAllocationIsFound()
+        {
+            var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetClosureAllocation);
+
+            Assert.AreEqual(1, issues.Count());
+
+            var issue = issues.First();
+
+            Assert.AreNotEqual(16707566, issue.line);
+            Assert.True(issue.description.Equals("'ClosureAllocation' closure allocation"));
+            Assert.True(issue.name.Equals("ClosureAllocation.Dummy"));
+            Assert.AreEqual(IssueCategory.Code, issue.category);
         }
 
         [Test]
@@ -92,9 +121,8 @@ class ParamsArrayAllocation
             var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetArrayAllocation);
             Assert.AreEqual(1, issues.Count());
 
-            var allocationIssue = issues.FirstOrDefault();
+            var allocationIssue = issues.First();
 
-            Assert.NotNull(allocationIssue);
             Assert.True(allocationIssue.description.Equals("'Int32' array allocation"));
             Assert.AreEqual(IssueCategory.Code, allocationIssue.category);
         }
@@ -105,10 +133,9 @@ class ParamsArrayAllocation
             var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetMultidimensionalArrayAllocation);
             Assert.AreEqual(1, issues.Count());
 
-            var allocationIssue = issues.FirstOrDefault();
+            var allocationIssue = issues.First();
 
-            Assert.NotNull(allocationIssue);
-            Assert.True(allocationIssue.description.Equals("'Int32[0...,0...]' object allocation"));
+            Assert.True(allocationIssue.description.Equals("'System.Int32[0...,0...]' allocation"));
             Assert.AreEqual(IssueCategory.Code, allocationIssue.category);
         }
 
@@ -118,10 +145,9 @@ class ParamsArrayAllocation
             var issues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetParamsArrayAllocation);
             Assert.AreEqual(1, issues.Count());
 
-            var allocationIssue = issues.FirstOrDefault();
+            var allocationIssue = issues.First();
 
-            Assert.NotNull(allocationIssue);
-            Assert.True(allocationIssue.description.Equals("'Object' array allocation"));
+            Assert.True(allocationIssue.description.Equals("'System.Object' allocation"));
             Assert.AreEqual(IssueCategory.Code, allocationIssue.category);
         }
     }

--- a/Tests/Editor/AllocationTests.cs
+++ b/Tests/Editor/AllocationTests.cs
@@ -147,7 +147,7 @@ class ParamsArrayAllocation
 
             var allocationIssue = issues.First();
 
-            Assert.True(allocationIssue.description.Equals("'System.Object' allocation"));
+            Assert.True(allocationIssue.description.Equals("'Object' array allocation"));
             Assert.AreEqual(IssueCategory.Code, allocationIssue.category);
         }
     }

--- a/Tests/Editor/ScriptIssueTests.cs
+++ b/Tests/Editor/ScriptIssueTests.cs
@@ -17,7 +17,6 @@ namespace UnityEditor.ProjectAuditor.EditorTests
         TempAsset m_TempAssetInPlayerCode;
         TempAsset m_TempAssetIssueInCoroutine;
         TempAsset m_TempAssetIssueInDelegate;
-        TempAsset m_TempAssetIssueInAllocatedDelegate;
         TempAsset m_TempAssetIssueInGenericClass;
         TempAsset m_TempAssetIssueInMonoBehaviour;
         TempAsset m_TempAssetIssueInNestedClass;
@@ -186,23 +185,6 @@ class ClassWithDelegate
 }
 ");
 
-            m_TempAssetIssueInAllocatedDelegate = new TempAsset("IssueInAllocatedDelegate.cs", @"
-using UnityEngine;
-using System;
-class ClassWithAllocatedDelegate
-{
-    private Func<int> myFunc;
-
-    void Dummy(int x)
-    {
-        myFunc = () =>
-        {
-            return x;
-        };
-    }
-}
-");
-
             m_TempAssetAnyApiInNamespace = new TempAsset("AnyApiInNamespace.cs", @"
 using System.Linq;
 using System.Collections.Generic;
@@ -362,16 +344,6 @@ class AnyApiInNamespace
             Assert.NotNull(issue);
             Assert.True(issue.GetCallingMethod().Equals("System.Int32 ClassWithDelegate/<>c::<Dummy>b__1_0()"));
         }
-
-        [Test]
-        public void IssueInAllocatedDelegateIsFound()
-        {
-            var allScriptIssues = ScriptIssueTestHelper.AnalyzeAndFindScriptIssues(m_TempAssetIssueInAllocatedDelegate);
-            var issue = allScriptIssues.FirstOrDefault(i => i.description.Equals("'<>c__DisplayClass1_0' object allocation"));
-            Assert.NotNull(issue);
-            Assert.AreNotEqual(16707566, issue.line);
-        }
-
 
         [Test]
         public void IssueInNamespaceIsFound()


### PR DESCRIPTION
**Problem**
There are a few problems related to Closure allocations reporting:
1. They are reported along with all other allocations. This is a problem on large projects which makes closure allocations hard to find.
2. The description is not very informative ("<>c__DisplayClass... object allocation")
3. The file line number is wrong

![closure-before](https://user-images.githubusercontent.com/12098182/109991396-335be880-7d02-11eb-931c-46ce67345b49.PNG)


**Solution**
This PR implements the following
1. Group all Closure allocations together by adding a new Descriptor.
2. In the description, use the type the Closure belongs to .
3. Fixes the line number

![closure-after](https://user-images.githubusercontent.com/12098182/109991423-38b93300-7d02-11eb-9a8a-329a4e42b1f2.PNG)

