### PR TITLE
Shader Variants workflow improvement

### DIFF
--- a/Editor/Auditors/ShadersAuditor.cs
+++ b/Editor/Auditors/ShadersAuditor.cs
@@ -113,6 +113,8 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         MethodInfo m_GetSRPBatcherCompatibilityCode;
 #pragma warning restore 0414
 
+        public static Action OnClearShaderData;
+
         public IEnumerable<ProblemDescriptor> GetDescriptors()
         {
             yield return null;
@@ -344,6 +346,8 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         internal static void ClearBuildData()
         {
             s_ShaderVariantData.Clear();
+            if (OnClearShaderData != null)
+                OnClearShaderData();
         }
 
         public int callbackOrder { get { return Int32.MaxValue; } }

--- a/Editor/UI/AnalysisView.cs
+++ b/Editor/UI/AnalysisView.cs
@@ -27,6 +27,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         public bool showRightPanels;
         public GUIContent dependencyViewGuiContent;
         public Action<Location> onDoubleClick;
+        public Action onDrawToolbarDataOptions;
         public Action<ProblemDescriptor> onOpenDescriptor;
         public ProjectAuditorAnalytics.UIButton analyticsEvent;
     }
@@ -252,6 +253,9 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         void DrawDataOptions()
         {
+            if (m_Desc.onDrawToolbarDataOptions != null)
+                m_Desc.onDrawToolbarDataOptions();
+
             if (Utility.ToolbarButtonWithDropdownList(Contents.ExportButton, k_ExportModeStrings,
                 OnExport, GUILayout.Width(80)))
             {

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -129,7 +129,12 @@ namespace Unity.ProjectAuditor.Editor.UI
             showRightPanels = false,
             onDrawToolbarDataOptions = () =>
             {
-                if (GUILayout.Button("Clear Build Data", EditorStyles.toolbarButton, GUILayout.ExpandWidth(true),
+                if (GUILayout.Button("Refresh", EditorStyles.toolbarButton, GUILayout.ExpandWidth(true),
+                    GUILayout.Width(100)))
+                {
+                    Instance.AnalyzeShaderVariants();
+                }
+                if (GUILayout.Button("Clear", EditorStyles.toolbarButton, GUILayout.ExpandWidth(true),
                 GUILayout.Width(100)))
                 {
                     ShadersAuditor.ClearBuildData();
@@ -219,6 +224,8 @@ namespace Unity.ProjectAuditor.Editor.UI
         void OnEnable()
         {
             ProjectAuditorAnalytics.EnableAnalytics();
+
+            ShadersAuditor.OnClearShaderData = OnClearShaderData;
 
             m_ProjectAuditor = new ProjectAuditor();
 
@@ -384,6 +391,13 @@ namespace Unity.ProjectAuditor.Editor.UI
                 m_AnalysisState = AnalysisState.NotStarted;
                 Debug.LogError(e);
             }
+        }
+
+        void OnClearShaderData()
+        {
+            m_ProjectReport.ClearIssues(IssueCategory.ShaderVariants);
+            if (m_ShaderVariantsWindow != null)
+                m_ShaderVariantsWindow.Clear();
         }
 
         void AnalyzeShaderVariants()
@@ -1048,14 +1062,6 @@ To Analyze the project, click on Analyze.
 Once the project is analyzed, the tool displays a list of issues of a specific kind. Initially, code-related issues will be shown.
 To switch type of issues, for example from code to settings-related issues, use the 'View' dropdown and select Settings.
 In addition, it is possible to filter issues by area (CPU/Memory/etc...), by string or by other search criteria.";
-        }
-
-
-        [PostProcessBuild(1)]
-        public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
-        {
-            if (Instance != null)
-                Instance.AnalyzeShaderVariants();
         }
     }
 }

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -127,6 +127,14 @@ namespace Unity.ProjectAuditor.Editor.UI
             showDependencyView = false,
             showMuteOptions = false,
             showRightPanels = false,
+            onDrawToolbarDataOptions = () =>
+            {
+                if (GUILayout.Button("Clear Build Data", EditorStyles.toolbarButton, GUILayout.ExpandWidth(true),
+                GUILayout.Width(100)))
+                {
+                    ShadersAuditor.ClearBuildData();
+                }
+            },
             onDoubleClick = FocusOnAssetInProjectWindow,
             analyticsEvent = ProjectAuditorAnalytics.UIButton.Shaders
         };
@@ -380,6 +388,9 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         void AnalyzeShaderVariants()
         {
+            if (m_ProjectReport == null)
+                m_ProjectReport = new ProjectReport();
+
             m_ProjectReport.ClearIssues(IssueCategory.Shaders);
             m_ProjectReport.ClearIssues(IssueCategory.ShaderVariants);
 

--- a/Editor/UI/ShaderVariantsWindow.cs
+++ b/Editor/UI/ShaderVariantsWindow.cs
@@ -11,7 +11,8 @@ namespace Unity.ProjectAuditor.Editor.UI
     class ShaderVariantsWindow : AnalysisWindow, IProjectIssueFilter
     {
         const string k_BuildRequiredInfo = @"
-Build the project and/or AssetBundles to view the Shader Variants
+- To view the built Shader Variants, run your build pipeline
+- To update after building AssetBundles, use the Refresh button
 ";
 
         const string k_PlayerLogInfo = @"

--- a/Editor/UI/ShaderVariantsWindow.cs
+++ b/Editor/UI/ShaderVariantsWindow.cs
@@ -11,7 +11,7 @@ namespace Unity.ProjectAuditor.Editor.UI
     class ShaderVariantsWindow : AnalysisWindow, IProjectIssueFilter
     {
         const string k_BuildRequiredInfo = @"
-Build the project to view the Shader Variants
+Build the project and/or AssetBundles to view the Shader Variants
 ";
 
         const string k_PlayerLogInfo = @"


### PR DESCRIPTION
**Problem**
There is a problem related to projects that rely on AssetBundles containing shaders. At the moment, the variants built into AssetBundles are not captured and reported by Project Auditor.

**Solution**
This is an attempt at fixing this problem and a workflow that take that into consideration. This PR adds two new buttons:
- Refresh: to update the reported variants, including AssetBundles variants
- Clear: to clear the currently reported variants
