### PR TITLE
Compiled variants improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added Generic types instantiation analysis
 * Added Summary view
 * Added Save&Load support
+* Added *Log Shader Compilation* option to Shader Variants window
 * Fixed Shader Variants persistence in UI after Domain Reload
+* Fixed Shader Variants *Compiled* column initial state
 * Fixed Code View sorting
 
 ## [0.5.0-preview] - 2021-03-11

--- a/Editor/UI/IssueTable.cs
+++ b/Editor/UI/IssueTable.cs
@@ -315,8 +315,11 @@ namespace Unity.ProjectAuditor.Editor.UI
                         var customProperty = issue.GetProperty(columnType);
                         if (customProperty != string.Empty)
                         {
-                            if (property.format == PropertyFormat.Bool)
-                                EditorGUI.Toggle(cellRect, customProperty.Equals(true.ToString()));
+                            bool boolValue;
+                            if (property.format == PropertyFormat.Bool && bool.TryParse(customProperty, out boolValue))
+                            {
+                                EditorGUI.Toggle(cellRect, boolValue);
+                            }
                             else
                                 EditorGUI.LabelField(cellRect, new GUIContent(customProperty), s_LabelStyle);
                         }

--- a/Editor/UI/ShaderVariantsWindow.cs
+++ b/Editor/UI/ShaderVariantsWindow.cs
@@ -10,21 +10,22 @@ namespace Unity.ProjectAuditor.Editor.UI
 {
     class ShaderVariantsWindow : AnalysisWindow, IProjectIssueFilter
     {
-        const string k_BuildRequiredInfo = @"
-Build the project to view the Shader Variants
-";
+        const string k_BuildRequiredInfo =
+@"Build the project to view the Shader Variants";
 
-        const string k_PlayerLogInstructions = @"
-To find which shader variants are compiled at runtime, follow these steps:
+        const string k_PlayerLogInstructions =
+@"This view shows the built Shader Variants.
+
+The number of Variants contributes to the build size, however, there might be Variants that are not required (compiled) at runtime on the target platform. To find out which of these variants are not compiled at runtime, follow these steps:
 - Enable the Log Shader Compilation option
 - Make a Development build
-- Run the build on the target platform
-- Drag & Drop the Player.log file on this window
-";
+- Run the build on the target platform. Make sure to go through all scenes.
+- Drag & Drop the Player.log file on this window";
 
-        const string k_PlayerLogParsingUnsupported = @"
-To find which shader variants are compiled at runtime, update to 2018 LTS or newer.
-";
+        const string k_PlayerLogParsingUnsupported =
+@"This view shows the built Shader Variants.
+
+The number of Variants contributes to the build size, however, there might be Variants that are not required (compiled) at runtime on the target platform. To find out which of these variants are not compiled at runtime, update to the latest Unity 2018+ LTS.";
 
         const string k_NoCompiledVariantWarning = "No compiled shader variants found in player log. Perhaps, Log Shader Compilation was not enabled when the project was built.";
         const string k_NoCompiledVariantWarningLogDisabled = "No compiled shader variants found in player log. Shader compilation logging is disabled. Would you like to enable it? (Shader compilation will not appear in the log until the project is rebuilt)";

--- a/Editor/UI/ShaderVariantsWindow.cs
+++ b/Editor/UI/ShaderVariantsWindow.cs
@@ -14,7 +14,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 Build the project to view the Shader Variants
 ";
 
-        const string k_PlayerLogInfo = @"
+        const string k_PlayerLogInstructions = @"
 To find which shader variants are compiled at runtime, follow these steps:
 - Enable the Log Shader Compilation option (Project Settings => Graphics => Shader Loading)
 - Make a Development build
@@ -73,7 +73,7 @@ To find which shader variants are compiled at runtime, follow these steps:
 
             EditorGUILayout.BeginVertical(GUI.skin.box);
 
-            m_AnalysisView.desc.onDrawInfo = variantsAvailable ? k_PlayerLogInfo : k_BuildRequiredInfo;
+            m_AnalysisView.desc.onDrawInfo = variantsAvailable ? k_PlayerLogInstructions : k_BuildRequiredInfo;
             m_AnalysisView.DrawInfo();
 
             var lastEnabled = GUI.enabled;

--- a/Editor/UI/ShaderVariantsWindow.cs
+++ b/Editor/UI/ShaderVariantsWindow.cs
@@ -16,11 +16,16 @@ Build the project to view the Shader Variants
 
         const string k_PlayerLogInstructions = @"
 To find which shader variants are compiled at runtime, follow these steps:
-- Enable the Log Shader Compilation option (Project Settings => Graphics => Shader Loading)
+- Enable the Log Shader Compilation option
 - Make a Development build
 - Run the build on the target platform
 - Drag & Drop the Player.log file on this window
 ";
+
+        const string k_PlayerLogParsingUnsupported = @"
+To find which shader variants are compiled at runtime, update to 2018 LTS or newer.
+";
+
         const string k_NoCompiledVariantWarning = "No compiled shader variants found in player log. Perhaps, Log Shader Compilation was not enabled when the project was built.";
         const string k_NoCompiledVariantWarningLogDisabled = "No compiled shader variants found in player log. Shader compilation logging is disabled. Would you like to enable it? (Shader compilation will not appear in the log until the project is rebuilt)";
         const string k_PlayerLogProcessed = "Player log file successfully processed.";
@@ -73,7 +78,17 @@ To find which shader variants are compiled at runtime, follow these steps:
 
             EditorGUILayout.BeginVertical(GUI.skin.box);
 
-            m_AnalysisView.desc.onDrawInfo = variantsAvailable ? k_PlayerLogInstructions : k_BuildRequiredInfo;
+            if (variantsAvailable)
+            {
+                m_AnalysisView.desc.onDrawInfo = GraphicsSettingsHelper.logShaderCompilationSupported
+                    ? k_PlayerLogInstructions
+                    : k_PlayerLogParsingUnsupported;
+            }
+            else
+            {
+                m_AnalysisView.desc.onDrawInfo = k_BuildRequiredInfo;
+            }
+
             m_AnalysisView.DrawInfo();
 
             var lastEnabled = GUI.enabled;
@@ -88,6 +103,10 @@ To find which shader variants are compiled at runtime, follow these steps:
                 m_AnalysisView.SetFlatView(m_FlatView);
                 m_AnalysisView.Refresh();
             }
+
+            if (GraphicsSettingsHelper.logShaderCompilationSupported)
+                GraphicsSettingsHelper.logWhenShaderIsCompiled = EditorGUILayout.ToggleLeft("Log Shader Compilation (requires Build&Run)", GraphicsSettingsHelper.logWhenShaderIsCompiled, GUILayout.Width(300));
+
             EditorGUILayout.EndHorizontal();
 
             GUI.enabled = lastEnabled;


### PR DESCRIPTION
**Problem**
In the Shader Variants window:
1. After a build, each variant _Compiled_ property should display a _?_ symbol to indicate the user hasn't provided the player log information (by dropping the player.log to the window). Unfortunately, the Compiled column shows a disabled checkbox instead. 
2. In some early Unity 2018 versions, shader compilation logging is supported but there is no UI option in the Graphics settings which leads to some confusion.

**Solution**

1. Fix the _Compiled_ property by displaying a _?_ symbol.
2. Expose "Log Shader Compilation" option in Shader Variants window and improve messaging to the user.

Build data is not available:
![build-required](https://user-images.githubusercontent.com/12098182/115260598-d0e06f80-a12a-11eb-83e4-133a991b8445.PNG)

Build data is available and  Player log is not available
![log-shader-compilation](https://user-images.githubusercontent.com/12098182/115260997-29b00800-a12b-11eb-81b0-b2d33e979325.PNG)

Log Shader Compilation unsupported
![unsupported](https://user-images.githubusercontent.com/12098182/115261151-464c4000-a12b-11eb-9015-0ef98043a494.PNG)

