### PR TITLE
Fixed crash when parsing ShaderCompilerData in 2021.2.0a16 or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Fixed *ShaderCompilerData* parsing in 2021.2.0a16 or newer
+
 ## [0.7.0-preview] - 2021-11-29
 * Added Documentation pages
 * Added UI Button to open documentation page based on active view


### PR DESCRIPTION
As of 2021.2.0a16, _ShaderCompilerData_ cannot longer be consumed after _OnProcessShader_ is executed. With this fix, _ShaderCompilerData_  is parsed immediately and relevant information is stored for later consumption.