### PR TITLE
Build Report: Fix unreported build files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Fixed unreported output files from the same source asset
 * Fixed *ShaderCompilerData* parsing in 2021.2.0a16 or newer
 
 ## [0.7.0-preview] - 2021-11-29

--- a/Editor/Modules/BuildReportModule.cs
+++ b/Editor/Modules/BuildReportModule.cs
@@ -359,41 +359,12 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             foreach (var packedAsset in buildReport.packedAssets)
             {
                 // note that there can be several entries for each source asset (for example, a prefab can reference a Texture, a Material and a shader)
-                var dict = new Dictionary<GUID, List<PackedAssetInfo>>();
                 foreach (var content in packedAsset.contents)
                 {
                     var assetPath = content.sourceAssetPath;
+
                     if (!Path.HasExtension(assetPath))
                         continue;
-
-                    if (Path.GetExtension(assetPath).Equals(".cs"))
-                        continue;
-
-                    if (!dict.ContainsKey(content.sourceAssetGUID))
-                    {
-                        dict.Add(content.sourceAssetGUID, new List<PackedAssetInfo>());
-                    }
-
-                    dict[content.sourceAssetGUID].Add(content);
-                }
-
-                foreach (var entry in dict)
-                {
-                    var content = entry.Value[0]; // sourceAssets are the same for all entries
-                    var assetPath = content.sourceAssetPath;
-
-                    ulong sum = 0;
-                    foreach (var v in entry.Value)
-                    {
-                        sum += v.packedSize;
-                    }
-
-                    var assetName = Path.GetFileNameWithoutExtension(assetPath);
-                    string description;
-                    if (entry.Value.Count > 1)
-                        description = string.Format("{0} ({1})", assetName, entry.Value.Count);
-                    else
-                        description = assetName;
 
                     ProblemDescriptor descriptor = null;
 
@@ -419,11 +390,13 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                             descriptor = k_OtherTypeDescriptor;
                         }
                     }
+
+                    var description = Path.GetFileNameWithoutExtension(assetPath);
                     var issue = new ProjectIssue(descriptor, description, IssueCategory.BuildFile, new Location(assetPath));
                     issue.SetCustomProperties(new object[(int)BuildReportFileProperty.Num]
                     {
                         content.type,
-                        sum,
+                        content.packedSize,
                         packedAsset.shortPath
                     });
                     onIssueFound(issue);


### PR DESCRIPTION
Build files are grouped together to report the total size that an asset contributes to the build. However, this shows the runtime type of the first file generated from a source asset, which lead to misleading / incomplete information. For example, an FBX would show a Material as the runtime type, even though a Mesh is also created at runtime.
![grouped-output-files](https://user-images.githubusercontent.com/12098182/144291472-b586630c-2a44-4b9b-86f7-c072ec6e0a18.PNG)



This PR fixes this issue.
![missing-output-files](https://user-images.githubusercontent.com/12098182/144291112-392e4f7f-19b0-4858-aafc-db047905d62c.PNG)

Note that we are "losing" the total sum, however, this is something we should bring back by adding a "group by" support in the UI.
