### PR TITLE
Fix creation of last BuildReport asset after build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed *ShaderCompilerData* parsing in 2021.2.0a16 or newer
 * Fixed disabling of unsupported modules
 * Fixed unreported output files from the same source asset
+* Fixed automatic creation of last BuildReport asset after build
 
 ## [0.7.0-preview] - 2021-11-29
 * Added Documentation pages

--- a/Editor/Modules/BuildReportModule.cs
+++ b/Editor/Modules/BuildReportModule.cs
@@ -39,13 +39,13 @@ namespace Unity.ProjectAuditor.Editor.Auditors
         const string k_BuildReportDir = "Assets/BuildReports";
         const string k_LastBuildReportPath = "Library/LastBuild.buildreport";
 
-        static BuildReport s_BuildReport;
-
         public BuildReport GetBuildReport()
         {
-            if (s_BuildReport != null)
-                return s_BuildReport;
+            return GetLastBuildReportAsset();
+        }
 
+        public static BuildReport GetLastBuildReportAsset()
+        {
             if (!Directory.Exists(k_BuildReportDir))
                 Directory.CreateDirectory(k_BuildReportDir);
 
@@ -59,8 +59,8 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 File.Copy(k_LastBuildReportPath, assetPath, true);
                 AssetDatabase.ImportAsset(assetPath);
             }
-            s_BuildReport = AssetDatabase.LoadAssetAtPath<BuildReport>(assetPath);
-            return s_BuildReport;
+
+            return AssetDatabase.LoadAssetAtPath<BuildReport>(assetPath);
         }
     }
 

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -54,6 +54,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         [SerializeField] string m_AssemblySelectionSummary;
         [SerializeField] ProjectReport m_ProjectReport;
         [SerializeField] AnalysisState m_AnalysisState = AnalysisState.Initializing;
+        [SerializeField] bool m_NewBuildAvailable = false;
         [SerializeField] Preferences m_Preferences = new Preferences();
         [SerializeField] ViewManager m_ViewManager;
 
@@ -460,11 +461,14 @@ namespace Unity.ProjectAuditor.Editor.UI
                 Repaint();
             if (m_AnalysisState == AnalysisState.InProgress)
                 Repaint();
+            if (m_NewBuildAvailable && LastBuildReportProvider.GetLastBuildReportAsset() != null)
+                m_NewBuildAvailable = false;
         }
 
         void OnPostprocessBuild(BuildTarget target)
         {
-            IncrementalAudit<BuildReportModule>();
+            // Note that we can't run BuildReportModule in OnPostprocessBuild because the Library/LastBuild.buildreport file is only created AFTER OnPostprocessBuild
+            m_NewBuildAvailable = true;
         }
 
         void IncrementalAudit<T>() where T : ProjectAuditorModule


### PR DESCRIPTION
Currently Project Auditor includes the last BuildReport as part of the analysis report. It is also supposed to update the BuildReport after each build. Unfortunately, this does not work well since the creation of the BuildReport asset relies on the OnPostprocessBuild callback. The problem with this callback is that the _Library/LastBuild.buildreport_ file is not created yet when OnPostprocessBuild is executed. The other problem is that the UI does not inform the user that the report has been updated.

With this PR we are changing the behaviour so that:
- a new BuildReport asset is always created from the last BuildReport after each a build, regardless of any Project Auditor analysis. This allows the user to easily select a BuildReport asset for viewing in the Inspector
- the BuildReport included in the Project Auditor analysis is the latest at the time of analysis and will never be updated