### PR TITLE
MonoBehavior.OnRenderObject/OnWillRenderObject as critical contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+* Added *OnRenderObject* and *OnWillRenderObject* to list of MonoBehavior critical contexts
+
 ## [0.7.3-preview] - 2022-03-01
 * Added *UnityEngine.Object.name* code diagnostic
 * Added *Severity* filters support

--- a/Editor/CodeAnalysis/MonoBehaviourAnalysis.cs
+++ b/Editor/CodeAnalysis/MonoBehaviourAnalysis.cs
@@ -14,7 +14,7 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
         static readonly string[] k_EventNames =
         {"Awake", "Start", "OnEnable", "OnDisable", "Update", "LateUpdate", "FixedUpdate"};
 
-        static readonly string[] k_UpdateMethodNames = {"Update", "LateUpdate", "FixedUpdate", "OnAnimatorIK", "OnAnimatorMove"};
+        static readonly string[] k_UpdateMethodNames = {"Update", "LateUpdate", "FixedUpdate", "OnAnimatorIK", "OnAnimatorMove", "OnWillRenderObject", "OnRenderObject"};
 
         public static bool IsMonoBehaviour(TypeReference typeReference)
         {

--- a/Tests/Editor/PerfCriticalContextTests.cs
+++ b/Tests/Editor/PerfCriticalContextTests.cs
@@ -10,6 +10,7 @@ namespace Unity.ProjectAuditor.EditorTests
         TempAsset m_TempAssetIssueInClassMethodCalledFromMonoBehaviourUpdate;
         TempAsset m_TempAssetIssueInMonoBehaviourUpdate;
         TempAsset m_TempAssetIssueInMonoBehaviourOnAnimatorMove;
+        TempAsset m_TempAssetIssueInMonoBehaviourOnRenderObject;
         TempAsset m_TempAssetIssueInSimpleClass;
         TempAsset m_TempAssetShaderWarmupIssueIsCritical;
 
@@ -43,6 +44,17 @@ using UnityEngine;
 class IssueInMonoBehaviourOnAnimatorMove : MonoBehaviour
 {
     void OnAnimatorMove()
+    {
+        Debug.Log(Camera.allCameras.Length);
+    }
+}
+");
+
+            m_TempAssetIssueInMonoBehaviourOnRenderObject = new TempAsset("m_TempAssetIssueInMonoBehaviourOnRenderObject.cs", @"
+using UnityEngine;
+class IssueInMonoBehaviourOnObjectRender : MonoBehaviour
+{
+    void OnRenderObject()
     {
         Debug.Log(Camera.allCameras.Length);
     }
@@ -125,6 +137,14 @@ class ShaderWarmUpIssueIsCritical
         public void CodeAnalysis_IssueInMonoBehaviourOnAnimatorMove_IsCritical()
         {
             var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInMonoBehaviourOnAnimatorMove);
+            var issue = issues.First();
+            Assert.True(issue.isPerfCriticalContext);
+        }
+
+        [Test]
+        public void CodeAnalysis_MonoBehaviourOnRenderObject_IsCriticalContext()
+        {
+            var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInMonoBehaviourOnRenderObject);
             var issue = issues.First();
             Assert.True(issue.isPerfCriticalContext);
         }


### PR DESCRIPTION
Added *OnRenderObject* and *OnWillRenderObject* to list of MonoBehavior critical contexts.