### PR TITLE
Feature/view sorting performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+* Added *OnRenderObject* and *OnWillRenderObject* to list of MonoBehavior critical contexts
+
 ## [0.7.3-preview] - 2022-03-01
 * Added *UnityEngine.Object.name* code diagnostic
 * Added *Severity* filters support

--- a/Editor/CodeAnalysis/MonoBehaviourAnalysis.cs
+++ b/Editor/CodeAnalysis/MonoBehaviourAnalysis.cs
@@ -14,7 +14,7 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
         static readonly string[] k_EventNames =
         {"Awake", "Start", "OnEnable", "OnDisable", "Update", "LateUpdate", "FixedUpdate"};
 
-        static readonly string[] k_UpdateMethodNames = {"Update", "LateUpdate", "FixedUpdate", "OnAnimatorIK", "OnAnimatorMove"};
+        static readonly string[] k_UpdateMethodNames = {"Update", "LateUpdate", "FixedUpdate", "OnAnimatorIK", "OnAnimatorMove", "OnWillRenderObject", "OnRenderObject"};
 
         public static bool IsMonoBehaviour(TypeReference typeReference)
         {

--- a/Editor/UI/Framework/AnalysisView.cs
+++ b/Editor/UI/Framework/AnalysisView.cs
@@ -427,9 +427,16 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
 
         void SetRowsExpanded(bool expanded)
         {
-            var rows = m_Table.GetRows();
-            foreach (var row in rows)
-                m_Table.SetExpanded(row.id, expanded);
+            if (expanded)
+            {
+                var rows = m_Table.GetRows();
+
+                m_Table.SetExpanded(rows.Select(r => r.id).ToList());
+            }
+            else
+            {
+                m_Table.SetExpanded(new List<int>());
+            }
         }
 
         void Export(Func<ProjectIssue, bool> predicate = null)

--- a/Editor/UI/Framework/IssueTable.cs
+++ b/Editor/UI/Framework/IssueTable.cs
@@ -537,24 +537,16 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                 m_Children.Sort(delegate(ItemTree a, ItemTree b)
                 {
                     var rtn = 0;
+
                     for (var i = 0; i < columnSortOrder.Length; i++)
                     {
-                        IssueTableItem firstItem;
-                        IssueTableItem secondItem;
+                        var order = isColumnAscending[i] ? 1 : -1;
+                        rtn = order * ProjectIssueExtensions.CompareTo(a.m_Item?.ProjectIssue, b.m_Item?.ProjectIssue, m_Layout.properties[columnSortOrder[i]].type);
 
-                        if (isColumnAscending[i])
-                        {
-                            firstItem = a.m_Item;
-                            secondItem = b.m_Item;
-                        }
-                        else
-                        {
-                            firstItem = b.m_Item;
-                            secondItem = a.m_Item;
-                        }
+                        if (rtn == 0)
+                            continue;
 
-                        var property = m_Layout.properties[columnSortOrder[i]];
-                        return firstItem.ProjectIssue.CompareTo(secondItem.ProjectIssue, property.type);
+                        return rtn;
                     }
 
                     return rtn;

--- a/Editor/UI/Framework/IssueTable.cs
+++ b/Editor/UI/Framework/IssueTable.cs
@@ -553,58 +553,8 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                             secondItem = a.m_Item;
                         }
 
-                        string firstString;
-                        string secondString;
-
                         var property = m_Layout.properties[columnSortOrder[i]];
-                        switch (property.type)
-                        {
-                            case PropertyType.Description:
-                                firstString = firstItem.GetDisplayName();
-                                secondString = secondItem.GetDisplayName();
-                                break;
-                            case PropertyType.Area:
-                                firstString = firstItem.ProblemDescriptor.GetAreasSummary();
-                                secondString = secondItem.ProblemDescriptor.GetAreasSummary();
-                                break;
-                            case PropertyType.Filename:
-                            case PropertyType.Path:
-                            case PropertyType.FileType:
-                                firstString = firstItem.ProjectIssue != null ? firstItem.ProjectIssue.GetProperty(property.type) : string.Empty;
-                                secondString = secondItem.ProjectIssue != null ? secondItem.ProjectIssue.GetProperty(property.type) : string.Empty;
-                                break;
-                            case PropertyType.Severity:
-                                if (firstItem.ProjectIssue != null && secondItem.ProjectIssue != null)
-                                    return secondItem.ProjectIssue.severity - firstItem.ProjectIssue.severity;
-                                firstString = firstItem.ProjectIssue != null ? firstItem.ProjectIssue.GetProperty(property.type) : string.Empty;
-                                secondString = secondItem.ProjectIssue != null ? secondItem.ProjectIssue.GetProperty(property.type) : string.Empty;
-                                break;
-                            default:
-                                if (property.format == PropertyFormat.Integer || property.format == PropertyFormat.Bytes)
-                                {
-                                    int first;
-                                    int second;
-                                    if (firstItem.ProjectIssue == null || !int.TryParse(firstItem.ProjectIssue.GetProperty(property.type), out first))
-                                        first = -999999;
-                                    if (secondItem.ProjectIssue == null || !int.TryParse(secondItem.ProjectIssue.GetProperty(property.type), out second))
-                                        second = -999999;
-                                    return first - second;
-                                }
-
-                                firstString = firstItem.ProjectIssue != null
-                                    ? firstItem.ProjectIssue.GetProperty(property.type)
-                                    : string.Empty;
-                                secondString = secondItem.ProjectIssue != null
-                                    ? secondItem.ProjectIssue.GetProperty(property.type)
-                                    : string.Empty;
-
-                                break;
-                        }
-
-                        rtn = string.Compare(firstString, secondString, StringComparison.Ordinal);
-                        if (rtn == 0)
-                            continue;
-                        return rtn;
+                        return firstItem.ProjectIssue.CompareTo(secondItem.ProjectIssue, property.type);
                     }
 
                     return rtn;

--- a/Editor/Utils/Location.cs
+++ b/Editor/Utils/Location.cs
@@ -23,9 +23,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
         {
             get
             {
-                if (string.IsNullOrEmpty(m_Path))
-                    return string.Empty;
-                return System.IO.Path.GetExtension(m_Path);
+                return System.IO.Path.GetExtension(m_Path) ?? string.Empty;
             }
         }
 
@@ -33,9 +31,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
         {
             get
             {
-                if (string.IsNullOrEmpty(m_Path))
-                    return string.Empty;
-                return m_Path;
+                return m_Path ?? string.Empty;
             }
         }
 

--- a/Editor/Utils/ProjectIssueExtensions.cs
+++ b/Editor/Utils/ProjectIssueExtensions.cs
@@ -129,6 +129,10 @@ namespace Unity.ProjectAuditor.Editor.Utils
         private static int GetExtensionIndexFromPath(string path)
         {
             int length = path.Length;
+
+            if (length == 0)
+                return 0;
+
             int num = length;
             while (--num >= 0)
             {

--- a/Editor/Utils/ProjectIssueExtensions.cs
+++ b/Editor/Utils/ProjectIssueExtensions.cs
@@ -131,12 +131,12 @@ namespace Unity.ProjectAuditor.Editor.Utils
                         return num;
                     }
 
-                    return -1;
+                    return length - 1;
                 }
 
                 if (c == System.IO.Path.DirectorySeparatorChar || c == System.IO.Path.AltDirectorySeparatorChar || c == System.IO.Path.VolumeSeparatorChar)
                 {
-                    return -1;
+                    return length - 1;
                 }
             }
             return length - 1;

--- a/Editor/Utils/ProjectIssueExtensions.cs
+++ b/Editor/Utils/ProjectIssueExtensions.cs
@@ -83,18 +83,17 @@ namespace Unity.ProjectAuditor.Editor.Utils
                     var filenameBIndex = GetFilenameIndexFromPath(filenameB);
 
                     var cf = string.CompareOrdinal(filenameA, filenameAIndex, filenameB, filenameBIndex, Math.Max(filenameA.Length, filenameB.Length));
-
-                    // TODO:Endswith is slow
-                    //if (cf == 0 && issueA.relativePath.EndsWith(".cs", StringComparison.Ordinal))
-                    if (cf == 0) // HACK: Skip type check. Assume that line means codefile. && issueA.relativePath.EndsWith(".cs", StringComparison.Ordinal))
+					
+					// If it's the same filename, see if the lines are different
+                    if (cf == 0)
                         return issueA.line.CompareTo(issueB.line);
 
                     return cf;
                 case PropertyType.Path:
                     var cp = string.CompareOrdinal(issueA.relativePath ?? string.Empty, issueB.relativePath ?? string.Empty);
 
-                    // TODO:Endswith is slow
-                    if (cp == 0) // HACK: Skip line check. Assume that line means codefile. && issueA.relativePath.EndsWith(".cs", StringComparison.Ordinal))
+                    // If it's the same path, see if the lines are different
+                    if (cp == 0)
                         return issueA.line.CompareTo(issueB.line);
 
                     return cp;

--- a/Editor/Utils/ProjectIssueExtensions.cs
+++ b/Editor/Utils/ProjectIssueExtensions.cs
@@ -48,6 +48,13 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
         public static int CompareTo(this ProjectIssue issueA, ProjectIssue issueB, PropertyType propertyType)
         {
+            if (issueA == null && issueB == null)
+                return 0;
+            if (issueA == null)
+                return -1;
+            if (issueB == null)
+                return 1;
+
             switch (propertyType)
             {
                 case PropertyType.Severity:

--- a/Editor/Utils/ProjectIssueExtensions.cs
+++ b/Editor/Utils/ProjectIssueExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Unity.ProjectAuditor.Editor.Utils
 {
@@ -83,8 +84,8 @@ namespace Unity.ProjectAuditor.Editor.Utils
                     var filenameBIndex = GetFilenameIndexFromPath(filenameB);
 
                     var cf = string.CompareOrdinal(filenameA, filenameAIndex, filenameB, filenameBIndex, Math.Max(filenameA.Length, filenameB.Length));
-					
-					// If it's the same filename, see if the lines are different
+
+                    // If it's the same filename, see if the lines are different
                     if (cf == 0)
                         return issueA.line.CompareTo(issueB.line);
 
@@ -106,10 +107,11 @@ namespace Unity.ProjectAuditor.Editor.Utils
                     var propB = issueB.GetCustomProperty(propertyIndex);
 
                     // Maybe instead of parsing, just assume the values are numbers and do it inplace?
-                    if (int.TryParse(propA, out var intA) && int.TryParse(propB, out var intB))
-                        return intA.CompareTo(intB);
+                    //if (int.TryParse(propA, out var intA) && int.TryParse(propB, out var intB))
+                    //    return intA.CompareTo(intB);
 
-                    return string.CompareOrdinal(propA, propB);
+                    //return string.CompareOrdinal(propA, propB);
+                    return UnsafeIntStringComparison(propA, propB);
             }
         }
 
@@ -155,6 +157,19 @@ namespace Unity.ProjectAuditor.Editor.Utils
                 }
             }
             return 0;
+        }
+
+        /// <summary>
+        /// Compares two strings, assuming they are both containing numerical characters only, skipping a lot of safety checks 
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int UnsafeIntStringComparison(string stringA, string stringB)
+        {
+            // Compare string length (simple and fast comparisson)
+            var c = stringA.Length.CompareTo(stringB.Length);
+
+            // If length is same, compare char-by-char, else use result of previous comparisson
+            return c == 0 ? string.CompareOrdinal(stringA, stringB) : c;
         }
     }
 }

--- a/Tests/Editor/PerfCriticalContextTests.cs
+++ b/Tests/Editor/PerfCriticalContextTests.cs
@@ -10,6 +10,7 @@ namespace Unity.ProjectAuditor.EditorTests
         TempAsset m_TempAssetIssueInClassMethodCalledFromMonoBehaviourUpdate;
         TempAsset m_TempAssetIssueInMonoBehaviourUpdate;
         TempAsset m_TempAssetIssueInMonoBehaviourOnAnimatorMove;
+        TempAsset m_TempAssetIssueInMonoBehaviourOnRenderObject;
         TempAsset m_TempAssetIssueInSimpleClass;
         TempAsset m_TempAssetShaderWarmupIssueIsCritical;
 
@@ -43,6 +44,17 @@ using UnityEngine;
 class IssueInMonoBehaviourOnAnimatorMove : MonoBehaviour
 {
     void OnAnimatorMove()
+    {
+        Debug.Log(Camera.allCameras.Length);
+    }
+}
+");
+
+            m_TempAssetIssueInMonoBehaviourOnRenderObject = new TempAsset("m_TempAssetIssueInMonoBehaviourOnRenderObject.cs", @"
+using UnityEngine;
+class IssueInMonoBehaviourOnObjectRender : MonoBehaviour
+{
+    void OnRenderObject()
     {
         Debug.Log(Camera.allCameras.Length);
     }
@@ -125,6 +137,14 @@ class ShaderWarmUpIssueIsCritical
         public void CodeAnalysis_IssueInMonoBehaviourOnAnimatorMove_IsCritical()
         {
             var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInMonoBehaviourOnAnimatorMove);
+            var issue = issues.First();
+            Assert.True(issue.isPerfCriticalContext);
+        }
+
+        [Test]
+        public void CodeAnalysis_MonoBehaviourOnRenderObject_IsCriticalContext()
+        {
+            var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInMonoBehaviourOnRenderObject);
             var issue = issues.First();
             Assert.True(issue.isPerfCriticalContext);
         }


### PR DESCRIPTION
Improved sorting performance for issue views. The old method of comparison allocated tons of strings on the heap due to the way it looked up properties, the new way does the comparisons in-place and shouldn't any allocate memory at all.

Before this change, with ~135K cases, I observed up to 60s to sort on certain properties. Now all sorts are ~1s on my machine.
