### PR TITLE
Optimize call tree building and visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added context menu item to open selected issue 
 * Fixed sorting of call hierarchy nodes
 * Optimized viewing and sorting UI performance
+* Optimized call tree building and visualization
 
 ## [0.7.3-preview] - 2022-03-01
 * Added *UnityEngine.Object.name* code diagnostic

--- a/Editor/CodeAnalysis/CallCrawler.cs
+++ b/Editor/CodeAnalysis/CallCrawler.cs
@@ -12,6 +12,7 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
         public readonly MethodReference caller;
         public readonly Location location;
         public readonly bool perfCriticalContext;
+        public CallTreeNode hierarchy;
 
         public CallInfo(
             MethodReference callee,
@@ -110,12 +111,21 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
                     // ignore recursive calls
                     if (!call.caller.FullName.Equals(callee.name))
                     {
-                        var callerInstance = new CallTreeNode(call.caller);
-                        callerInstance.location = call.location;
-                        callerInstance.perfCriticalContext = call.perfCriticalContext;
+                        if (call.hierarchy != null)
+                        {
+                            // use previously built hierarchy
+                            callee.AddChild(call.hierarchy);
+                        }
+                        else
+                        {
+                            var hierarchy = new CallTreeNode(call.caller);
+                            hierarchy.location = call.location;
+                            hierarchy.perfCriticalContext = call.perfCriticalContext;
 
-                        BuildHierarchy(callerInstance, depth);
-                        callee.AddChild(callerInstance);
+                            BuildHierarchy(hierarchy, depth);
+                            callee.AddChild(hierarchy);
+                            call.hierarchy = hierarchy;
+                        }
                     }
             }
         }

--- a/Editor/CodeAnalysis/CallCrawler.cs
+++ b/Editor/CodeAnalysis/CallCrawler.cs
@@ -49,30 +49,24 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
     {
         const int k_MaxDepth = 10;
 
+        // key: callee name, value: lists of all callers
         readonly Dictionary<string, List<CallInfo>> m_BucketedCalls =
             new Dictionary<string, List<CallInfo>>();
 
-        readonly HashSet<CallInfo> m_Calls = new HashSet<CallInfo>();
-
         public void Add(CallInfo callInfo)
         {
-            m_Calls.Add(callInfo);
+            var key = callInfo.callee.FullName;
+            List<CallInfo> calls;
+            if (!m_BucketedCalls.TryGetValue(key, out calls))
+            {
+                calls = new List<CallInfo>();
+                m_BucketedCalls.Add(key, calls);
+            }
+            calls.Add(callInfo);
         }
 
         public void BuildCallHierarchies(List<ProjectIssue> issues, IProgress progress = null)
         {
-            foreach (var callInfo in m_Calls)
-            {
-                var key = callInfo.callee.FullName;
-                List<CallInfo> calls;
-                if (!m_BucketedCalls.TryGetValue(key, out calls))
-                {
-                    calls = new List<CallInfo>();
-                    m_BucketedCalls.Add(key, calls);
-                }
-                calls.Add(callInfo);
-            }
-
             if (issues.Count > 0)
             {
                 Profiler.BeginSample("CallCrawler.BuildCallHierarchies");

--- a/Editor/CodeAnalysis/CallCrawler.cs
+++ b/Editor/CodeAnalysis/CallCrawler.cs
@@ -80,14 +80,12 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
                         progress.Advance();
 
                     const int depth = 0;
-                    var callTree = issue.dependencies;
-                    BuildHierarchy(callTree.GetChild() as CallTreeNode, depth);
+                    var root = issue.dependencies;
+                    BuildHierarchy(root as CallTreeNode, depth);
 
-                    // temp fix for null location (ScriptAuditor was unable to get sequence point)
-                    if (issue.location == null && callTree.HasChildren())
-                    {
-                        issue.location = callTree.GetChild().location;
-                    }
+                    // temp fix for null location (code analysis was unable to get sequence point)
+                    if (issue.location == null)
+                        issue.location = root.location;
                 }
                 if (progress != null)
                     progress.Clear();

--- a/Editor/CodeAnalysis/CallTreeNode.cs
+++ b/Editor/CodeAnalysis/CallTreeNode.cs
@@ -69,7 +69,7 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
 
         public override bool IsPerfCritical()
         {
-            return perfCriticalContext || (HasChildren() && m_Children.Any(child => child.IsPerfCritical()));
+            return perfCriticalContext;
         }
     }
 }

--- a/Editor/CodeAnalysis/CodeIssueExtensions.cs
+++ b/Editor/CodeAnalysis/CodeIssueExtensions.cs
@@ -8,12 +8,8 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
         {
             if (issue.dependencies == null)
                 return string.Empty;
-            if (!issue.dependencies.HasChildren())
-                return string.Empty;
 
-            var callTree = issue.dependencies.GetChild() as CallTreeNode;
-            if (callTree == null)
-                return string.Empty;
+            var callTree = (CallTreeNode)issue.dependencies;
             return callTree.name;
         }
     }

--- a/Editor/CodeAnalysis/MonoCecilHelper.cs
+++ b/Editor/CodeAnalysis/MonoCecilHelper.cs
@@ -5,8 +5,10 @@ using Mono.Cecil;
 
 namespace Unity.ProjectAuditor.Editor.CodeAnalysis
 {
-    static class MonoCecilHelper
+    internal static class MonoCecilHelper
     {
+        public const int HiddenLine = 16707566;
+
         // for reference https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/MonoCecil/MonoCecilHelper.cs
         public static IEnumerable<TypeDefinition> AggregateAllTypeDefinitions(IEnumerable<TypeDefinition> types)
         {

--- a/Editor/DependencyNode.cs
+++ b/Editor/DependencyNode.cs
@@ -7,7 +7,7 @@ namespace Unity.ProjectAuditor.Editor
 {
     public abstract class DependencyNode
     {
-        protected List<DependencyNode> m_Children = new List<DependencyNode>();
+        protected List<DependencyNode> m_Children = new List<DependencyNode>(1);
 
         public Location location;
         public bool perfCriticalContext;

--- a/Editor/DependencyNode.cs
+++ b/Editor/DependencyNode.cs
@@ -34,6 +34,10 @@ namespace Unity.ProjectAuditor.Editor
 
         internal void AddChildren(DependencyNode[] children)
         {
+            // if any child is critical, make parent critical too
+            // this is to propagate perfCriticalContext up to the root of the hierarchy
+            if (children.Any(c => c.perfCriticalContext))
+                perfCriticalContext = true;
             m_Children.AddRange(children);
         }
 

--- a/Editor/DependencyNode.cs
+++ b/Editor/DependencyNode.cs
@@ -32,6 +32,11 @@ namespace Unity.ProjectAuditor.Editor
             m_Children.Add(child);
         }
 
+        internal void AddChildren(DependencyNode[] children)
+        {
+            m_Children.AddRange(children);
+        }
+
         public DependencyNode GetChild(int index = 0)
         {
             return m_Children[index];

--- a/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
@@ -52,7 +52,6 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 if (typeReference.IsValueType)
                     return null;
 
-                var calleeNode = new CallTreeNode(methodDefinition);
                 var isClosure = typeReference.Name.StartsWith("<>c__DisplayClass");
                 if (isClosure)
                 {
@@ -60,8 +59,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                     (
                         k_ClosureAllocationDescriptor,
                         string.Format("Closure allocation in {0}.{1}", typeReference.DeclaringType.FullName, methodDefinition.Name),
-                        IssueCategory.Code,
-                        calleeNode
+                        IssueCategory.Code
                     );
                 }
 
@@ -69,8 +67,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 (
                     k_ObjectAllocationDescriptor,
                     string.Format("'{0}' allocation", typeReference.FullName),
-                    IssueCategory.Code,
-                    calleeNode
+                    IssueCategory.Code
                 );
             }
             else // OpCodes.Newarr
@@ -78,14 +75,11 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 var typeReference = (TypeReference)inst.Operand;
                 var description = string.Format("'{0}' array allocation", typeReference.Name);
 
-                var calleeNode = new CallTreeNode(methodDefinition);
-
                 return new ProjectIssue
                 (
                     k_ArrayAllocationDescriptor,
                     description,
-                    IssueCategory.Code,
-                    calleeNode
+                    IssueCategory.Code
                 );
             }
         }

--- a/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
@@ -54,8 +54,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
             (
                 k_Descriptor,
                 description,
-                IssueCategory.Code,
-                calleeNode
+                IssueCategory.Code
             );
         }
 

--- a/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
@@ -48,7 +48,6 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 typeName = "double";
 
             var description = string.Format("Conversion from value type '{0}' to ref type", typeName);
-            var calleeNode = new CallTreeNode(methodDefinition);
 
             return new ProjectIssue
             (

--- a/Editor/InstructionAnalyzers/BuiltinCallAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BuiltinCallAnalyzer.cs
@@ -84,8 +84,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
             (
                 descriptor,
                 description,
-                IssueCategory.Code,
-                new CallTreeNode(callee)
+                IssueCategory.Code
             );
         }
 

--- a/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
@@ -43,8 +43,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
             (
                 k_Descriptor,
                 methodDefinition.FullName,
-                IssueCategory.Code,
-                new CallTreeNode(methodDefinition)
+                IssueCategory.Code
             );
         }
 

--- a/Editor/InstructionAnalyzers/GenericTypeInstantiationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/GenericTypeInstantiationAnalyzer.cs
@@ -19,10 +19,10 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         public ProjectIssue Analyze(MethodDefinition methodDefinition, Instruction inst)
         {
-            return AnalyzeType(methodDefinition, inst.OpCode == OpCodes.Newobj ? ((MethodReference)inst.Operand).DeclaringType : (TypeReference)inst.Operand);
+            return AnalyzeType(inst.OpCode == OpCodes.Newobj ? ((MethodReference)inst.Operand).DeclaringType : (TypeReference)inst.Operand);
         }
 
-        ProjectIssue AnalyzeType(MethodDefinition methodDefinition, TypeReference typeReference)
+        ProjectIssue AnalyzeType(TypeReference typeReference)
         {
             if (!typeReference.IsGenericInstance)
                 return null;
@@ -37,7 +37,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                     m_GenericDescriptors.Add(typeDefinition.FullName, desc);
                 }
 
-                return new ProjectIssue(m_GenericDescriptors[genericTypeName], typeReference.FullName, IssueCategory.GenericInstance, new CallTreeNode(methodDefinition));
+                return new ProjectIssue(m_GenericDescriptors[genericTypeName], typeReference.FullName, IssueCategory.GenericInstance);
             }
             catch (AssemblyResolutionException e)
             {

--- a/Editor/Modules/CodeModule.cs
+++ b/Editor/Modules/CodeModule.cs
@@ -295,11 +295,14 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
             Profiler.BeginSample("CodeModule.AnalyzeMethodBody");
 
-            var callerNode = new CallTreeNode(caller);
-
             Profiler.BeginSample("CodeModule.IsPerformanceCriticalContext");
             var perfCriticalContext = IsPerformanceCriticalContext(caller);
             Profiler.EndSample();
+
+            var callerNode = new CallTreeNode(caller)
+            {
+                perfCriticalContext = perfCriticalContext
+            };
 
             foreach (var inst in caller.Body.Instructions.Where(i => m_OpCodes.Contains(i.OpCode)))
             {
@@ -342,8 +345,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                         var projectIssue = analyzer.Analyze(caller, inst);
                         if (projectIssue != null)
                         {
-                            projectIssue.dependencies.perfCriticalContext = perfCriticalContext;
-                            projectIssue.dependencies.AddChild(callerNode);
+                            projectIssue.dependencies = callerNode; // set root
                             projectIssue.location = location;
                             projectIssue.SetCustomProperties(new string[(int)CodeProperty.Num] {assemblyInfo.name});
 

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -103,20 +103,6 @@ namespace Unity.ProjectAuditor.Editor
             }
         }
 
-        public string name
-        {
-            get
-            {
-                if (dependencies == null)
-                    return string.Empty;
-                var prettyName = dependencies.prettyName;
-                if (prettyName.Equals(descriptor.description))
-                    // if name matches the descriptor's name, use caller's name instead
-                    return string.IsNullOrEmpty(this.GetCallingMethod()) ? string.Empty : dependencies.GetChild().prettyName;
-                return prettyName;
-            }
-        }
-
         public int GetNumCustomProperties()
         {
             return customProperties != null ? customProperties.Length : 0;

--- a/Editor/ProjectIssue.cs
+++ b/Editor/ProjectIssue.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Linq;
-using Unity.ProjectAuditor.Editor.CodeAnalysis;
+using Unity.ProjectAuditor.Editor.CodeAnalysis;// TODO: remove dependency on CodeAnalysis
 using Unity.ProjectAuditor.Editor.Utils;
 using UnityEngine;
 
@@ -59,15 +59,6 @@ namespace Unity.ProjectAuditor.Editor
         {
             if (customProperties != null)
                 this.customProperties = customProperties.Select(p => p.ToString()).ToArray();
-        }
-
-        public ProjectIssue(ProblemDescriptor descriptor,
-                            string description,
-                            IssueCategory category,
-                            CallTreeNode dependenciesNode)
-            : this(descriptor, description, category)
-        {
-            dependencies = dependenciesNode;
         }
 
         public int depth = 0;

--- a/Editor/UI/Framework/AnalysisView.cs
+++ b/Editor/UI/Framework/AnalysisView.cs
@@ -398,18 +398,10 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                 else// if (issues.Length == 1)
                 {
                     var selection = issues[0];
-                    DependencyNode dependencies = null;
-                    if (selection != null && selection.dependencies != null)
-                    {
-                        if (selection.dependencies as CallTreeNode != null)
-                            dependencies = selection.dependencies.GetChild(); // skip self
-                        else
-                            dependencies = selection.dependencies;
-                    }
 
-                    m_DependencyView.SetRoot(dependencies);
+                    m_DependencyView.SetRoot(selection.dependencies);
 
-                    if (dependencies != null)
+                    if (selection.dependencies != null)
                     {
                         var r = EditorGUILayout.GetControlRect(GUILayout.ExpandHeight(true));
 

--- a/Editor/UI/Framework/IssueTable.cs
+++ b/Editor/UI/Framework/IssueTable.cs
@@ -75,7 +75,7 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                 var depth = issue.depth;
                 if (m_Desc.groupByDescriptor)
                     depth++;
-                var item = new IssueTableItem(m_NextId++, depth, issue.name, issue.descriptor, issue);
+                var item = new IssueTableItem(m_NextId++, depth, issue.description, issue.descriptor, issue);
                 itemsList.Add(item);
             }
 

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -158,7 +158,6 @@ namespace Unity.ProjectAuditor.Editor
         public string relativePath { get; }
         public Unity.ProjectAuditor.Editor.Rule.Severity severity { get; }
         public ProjectIssue(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor, string description, Unity.ProjectAuditor.Editor.IssueCategory category, object[] customProperties) {}
-        public ProjectIssue(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor, string description, Unity.ProjectAuditor.Editor.IssueCategory category, Unity.ProjectAuditor.Editor.CodeAnalysis.CallTreeNode dependenciesNode) {}
         public ProjectIssue(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor, string description, Unity.ProjectAuditor.Editor.IssueCategory category, string path, object[] customProperties) {}
         public ProjectIssue(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor, string description, Unity.ProjectAuditor.Editor.IssueCategory category, Unity.ProjectAuditor.Editor.Utils.Location location = default(Unity.ProjectAuditor.Editor.Utils.Location), object[] customProperties = default(object[])) {}
         public string GetCustomProperty<T>(T propertyEnum) where T : System.ValueType, new();

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -154,7 +154,6 @@ namespace Unity.ProjectAuditor.Editor
         public string filename { get; }
         public bool isPerfCriticalContext { get; }
         public int line { get; }
-        public string name { get; }
         public string relativePath { get; }
         public Unity.ProjectAuditor.Editor.Rule.Severity severity { get; }
         public ProjectIssue(Unity.ProjectAuditor.Editor.ProblemDescriptor descriptor, string description, Unity.ProjectAuditor.Editor.IssueCategory category, object[] customProperties) {}

--- a/Tests/Editor/AllocationTests.cs
+++ b/Tests/Editor/AllocationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
+using Unity.ProjectAuditor.Editor.CodeAnalysis;
 
 namespace Unity.ProjectAuditor.EditorTests
 {
@@ -109,7 +110,7 @@ class ParamsArrayAllocation
 
             var issue = issues.First();
 
-            Assert.AreNotEqual(16707566, issue.line);
+            Assert.AreNotEqual(MonoCecilHelper.HiddenLine, issue.line);
             Assert.AreEqual("Closure allocation in ClosureAllocation.Dummy", issue.description);
             Assert.AreEqual(IssueCategory.Code, issue.category);
         }

--- a/Tests/Editor/BoxingIssueTests.cs
+++ b/Tests/Editor/BoxingIssueTests.cs
@@ -43,7 +43,6 @@ namespace Unity.ProjectAuditor.EditorTests
 
             // check issue
             Assert.NotNull(boxingInt);
-            Assert.AreEqual("BoxingIntTest.Dummy", boxingInt.name);
             Assert.AreEqual(m_TempAssetBoxingInt.fileName, boxingInt.filename);
             Assert.AreEqual("Conversion from value type 'Int32' to ref type", boxingInt.description);
             Assert.AreEqual("System.Object BoxingIntTest::Dummy()", boxingInt.GetCallingMethod());
@@ -71,7 +70,6 @@ namespace Unity.ProjectAuditor.EditorTests
 
             // check issue
             Assert.NotNull(boxingFloat);
-            Assert.AreEqual("BoxingFloatTest.Dummy", boxingFloat.name);
             Assert.AreEqual(m_TempAssetBoxingFloat.fileName, boxingFloat.filename);
             Assert.AreEqual("Conversion from value type 'float' to ref type", boxingFloat.description);
             Assert.AreEqual("System.Object BoxingFloatTest::Dummy()", boxingFloat.GetCallingMethod());

--- a/Tests/Editor/CallTreeTests.cs
+++ b/Tests/Editor/CallTreeTests.cs
@@ -84,8 +84,7 @@ class HierarchyTest
             Assert.AreEqual("Assembly-CSharp.dll", root.assemblyName);
             Assert.AreEqual("CallerMethod", root.methodName);
             Assert.AreEqual("RootTest", root.typeName);
-            Assert.AreEqual(1, root.GetNumChildren());
-            Assert.AreEqual(0, root.GetChild().GetNumChildren());
+            Assert.AreEqual(0, root.GetNumChildren());
         }
 
         [Test]
@@ -98,7 +97,7 @@ class HierarchyTest
             Assert.NotNull(root);
             Assert.AreEqual("X", root.methodName);
             Assert.AreEqual("RecursiveTest", root.typeName);
-            Assert.AreEqual(0, root.GetChild().GetChild().GetNumChildren());
+            Assert.AreEqual(0, root.GetChild().GetNumChildren());
         }
 
         [Test]
@@ -114,11 +113,11 @@ class HierarchyTest
             Assert.NotNull(rootX);
             Assert.NotNull(rootY);
 
-            var A2X = rootX.GetChild().GetChild();
-            var B2Y = rootY.GetChild().GetChild();
+            var A2X = rootX.GetChild();
+            var B2Y = rootY.GetChild();
 
             // check C=>B nodes are the same
-            Assert.True(ReferenceEquals(A2X.GetChild().GetChild(), B2Y.GetChild()));
+            Assert.True(ReferenceEquals(A2X.GetChild(), B2Y));
         }
     }
 }

--- a/Tests/Editor/CallTreeTests.cs
+++ b/Tests/Editor/CallTreeTests.cs
@@ -101,7 +101,7 @@ class HierarchyTest
         }
 
         [Test]
-        public void CallTree_SubHierarchy_IsSame()
+        public void CallTree_SameSubHierarchy_IsUnique()
         {
             var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetHierarchy);
 
@@ -117,7 +117,7 @@ class HierarchyTest
             var B2Y = rootY.GetChild();
 
             // check C=>B nodes are the same
-            Assert.True(ReferenceEquals(A2X.GetChild(), B2Y));
+            Assert.True(ReferenceEquals(A2X.GetChild().GetChild(), B2Y.GetChild()));
         }
     }
 }

--- a/Tests/Editor/CallTreeTests.cs
+++ b/Tests/Editor/CallTreeTests.cs
@@ -1,0 +1,100 @@
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor.CodeAnalysis;
+
+namespace Unity.ProjectAuditor.EditorTests
+{
+    class CallTreeTests
+    {
+        TempAsset m_TempAsset;
+        TempAsset m_TempAssetHierarchy;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            m_TempAsset = new TempAsset("RootTest.cs", @"
+using System;
+class RootTest
+{
+    Object CallerMethod()
+    {
+        return 5;
+    }
+}");
+
+
+// the same sub-hierarchy should only be computed once
+// Issue:     X      Y
+//            |      |
+//            A      B
+//            |      |
+//            B      C
+//            |
+//            C
+//
+//  method C calling into B should be the same for both issue X and Y
+
+            m_TempAssetHierarchy = new TempAsset("HierarchyTest.cs", @"
+using System;
+class HierarchyTest
+{
+    Object X()
+    {
+        return 5;
+    }
+
+    Object Y()
+    {
+        return 5;
+    }
+
+    void A() { X(); }
+    void B() { A(); Y(); }
+    void C() { B(); }
+}");
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            TempAsset.Cleanup();
+        }
+
+        [Test]
+        public void CallTree_Root_IsValid()
+        {
+            var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAsset);
+
+            Assert.AreEqual(1, issues.Length);
+
+            var root = issues[0].dependencies as CallTreeNode;
+
+            Assert.NotNull(root);
+            Assert.AreEqual("System.Object RootTest::CallerMethod()", root.name);
+            Assert.AreEqual("Assembly-CSharp.dll", root.assemblyName);
+            Assert.AreEqual("CallerMethod", root.methodName);
+            Assert.AreEqual("RootTest", root.typeName);
+            Assert.AreEqual(1, root.GetNumChildren());
+            Assert.AreEqual(0, root.GetChild().GetNumChildren());
+        }
+
+        [Test]
+        public void CallTree_SubHierarchy_IsSame()
+        {
+            var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetHierarchy);
+
+            Assert.AreEqual(2, issues.Length);
+
+            var rootX = issues[0].dependencies as CallTreeNode;
+            var rootY = issues[1].dependencies as CallTreeNode;
+
+            Assert.NotNull(rootX);
+            Assert.NotNull(rootY);
+
+            var A2X = rootX.GetChild().GetChild();
+            var B2Y = rootY.GetChild().GetChild();
+
+            // check C=>B nodes are the same
+            Assert.True(ReferenceEquals(A2X.GetChild().GetChild(), B2Y.GetChild()));
+        }
+    }
+}

--- a/Tests/Editor/CallTreeTests.cs
+++ b/Tests/Editor/CallTreeTests.cs
@@ -7,6 +7,7 @@ namespace Unity.ProjectAuditor.EditorTests
     {
         TempAsset m_TempAsset;
         TempAsset m_TempAssetHierarchy;
+        TempAsset m_TempAssetRecursive;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -21,6 +22,16 @@ class RootTest
     }
 }");
 
+            m_TempAssetRecursive = new TempAsset("RecursiveTest.cs", @"
+using System;
+class RecursiveTest
+{
+    Object X()
+    {
+        X();
+        return 5;
+    }
+}");
 
 // the same sub-hierarchy should only be computed once
 // Issue:     X      Y
@@ -75,6 +86,19 @@ class HierarchyTest
             Assert.AreEqual("RootTest", root.typeName);
             Assert.AreEqual(1, root.GetNumChildren());
             Assert.AreEqual(0, root.GetChild().GetNumChildren());
+        }
+
+        [Test]
+        public void CallTree_Hierarchy_IsNotRecursive()
+        {
+            var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetRecursive);
+
+            var root = issues[0].dependencies as CallTreeNode;
+
+            Assert.NotNull(root);
+            Assert.AreEqual("X", root.methodName);
+            Assert.AreEqual("RecursiveTest", root.typeName);
+            Assert.AreEqual(0, root.GetChild().GetChild().GetNumChildren());
         }
 
         [Test]

--- a/Tests/Editor/CallTreeTests.cs.meta
+++ b/Tests/Editor/CallTreeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41325d40f9032354cbf1aa13bdab8118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/CodeAnalysisTests.cs
+++ b/Tests/Editor/CodeAnalysisTests.cs
@@ -352,7 +352,6 @@ class UxmlAttributeDescriptionPropertyUsage
             Assert.AreEqual("UnityEngine.Camera", myIssue.descriptor.type);
             Assert.AreEqual("allCameras", myIssue.descriptor.method);
 
-            Assert.AreEqual("Camera.get_allCameras", myIssue.name);
             Assert.AreEqual(m_TempAsset.fileName, myIssue.filename);
             Assert.AreEqual("UnityEngine.Camera.allCameras", myIssue.description);
             Assert.AreEqual("System.Void MyClass::Dummy()", myIssue.GetCallingMethod());
@@ -454,7 +453,7 @@ class UxmlAttributeDescriptionPropertyUsage
         public void CodeAnalysis_IssueInDelegate_IsReported()
         {
             var allScriptIssues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInDelegate);
-            var issue = allScriptIssues.FirstOrDefault(i => i.name.Equals("Camera.get_allCameras"));
+            var issue = allScriptIssues.FirstOrDefault(i => i.description.Equals("UnityEngine.Camera.allCameras"));
             Assert.NotNull(issue);
             Assert.AreEqual("System.Int32 ClassWithDelegate/<>c::<Dummy>b__1_0()", issue.GetCallingMethod());
         }
@@ -465,7 +464,7 @@ class UxmlAttributeDescriptionPropertyUsage
             var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInProperty, IssueCategory.Code);
 
             Assert.AreEqual(1, issues.Length);
-            Assert.AreEqual("IssueInProperty.get_property", issues[0].name);
+            Assert.AreEqual("IssueInProperty.property", issues[0].description);
         }
 
         [Test]
@@ -484,7 +483,6 @@ class UxmlAttributeDescriptionPropertyUsage
             var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetObjectName);
 
             Assert.AreEqual(3, issues.Length);
-            Assert.True(issues.All(i => i.name.Equals("Object.get_name")));
             Assert.True(issues.All(i => i.description.Equals("UnityEngine.Object.name")));
         }
 

--- a/Tests/Editor/CodeAnalysisTests.cs
+++ b/Tests/Editor/CodeAnalysisTests.cs
@@ -464,7 +464,8 @@ class UxmlAttributeDescriptionPropertyUsage
             var issues = Utility.AnalyzeAndFindAssetIssues(m_TempAssetIssueInProperty, IssueCategory.Code);
 
             Assert.AreEqual(1, issues.Length);
-            Assert.AreEqual("IssueInProperty.property", issues[0].description);
+            Assert.AreEqual("Conversion from value type 'Int32' to ref type", issues[0].description);
+            Assert.AreEqual("IssueInProperty.get_property", issues[0].dependencies.prettyName);
         }
 
         [Test]

--- a/Tests/Editor/LinqIssueTests.cs
+++ b/Tests/Editor/LinqIssueTests.cs
@@ -50,7 +50,6 @@ class MyClass
             Assert.AreEqual("System.Linq", myIssue.descriptor.type);
             Assert.AreEqual("*", myIssue.descriptor.method);
 
-            Assert.AreEqual("Enumerable.Count", myIssue.name);
             Assert.AreEqual(m_TempAsset.fileName, myIssue.filename);
             Assert.AreEqual("System.Linq.Enumerable.Count", myIssue.description, "Description: {0}", myIssue.description);
             Assert.AreEqual("System.Int32 MyClass::Dummy(System.Collections.Generic.List`1<System.Int32>)", myIssue.GetCallingMethod());

--- a/Tests/Editor/MonoBehaviourEmptyMethodTests.cs
+++ b/Tests/Editor/MonoBehaviourEmptyMethodTests.cs
@@ -55,7 +55,6 @@ namespace Unity.ProjectAuditor.EditorTests
             Assert.True(string.IsNullOrEmpty(issue.descriptor.type));
             Assert.True(string.IsNullOrEmpty(issue.descriptor.method));
 
-            Assert.AreEqual("MonoBehaviourWithEmptyEventMethod.Update", issue.name);
             Assert.AreEqual(m_MonoBehaviourWithEmptyEventMethod.fileName, issue.filename);
             Assert.AreEqual("System.Void MonoBehaviourWithEmptyEventMethod::Update()", issue.description);
             Assert.AreEqual("System.Void MonoBehaviourWithEmptyEventMethod::Update()", issue.GetCallingMethod());

--- a/Tests/Editor/ProjectIssueTests.cs
+++ b/Tests/Editor/ProjectIssueTests.cs
@@ -20,11 +20,12 @@ namespace Unity.ProjectAuditor.EditorTests
         [Test]
         public void ProjectIssue_NewIssue_IsInitialized()
         {
-            var uninitialised = new ProjectIssue(s_Descriptor, "dummy issue", IssueCategory.Code);
+            var description = "dummy issue";
+            var uninitialised = new ProjectIssue(s_Descriptor, description, IssueCategory.Code);
             Assert.AreEqual(string.Empty, uninitialised.filename);
             Assert.AreEqual(string.Empty, uninitialised.relativePath);
             Assert.AreEqual(string.Empty, uninitialised.GetCallingMethod());
-            Assert.AreEqual(string.Empty, uninitialised.description);
+            Assert.AreEqual(description, uninitialised.description);
             Assert.False(uninitialised.isPerfCriticalContext);
         }
 

--- a/Tests/Editor/ProjectIssueTests.cs
+++ b/Tests/Editor/ProjectIssueTests.cs
@@ -24,7 +24,7 @@ namespace Unity.ProjectAuditor.EditorTests
             Assert.AreEqual(string.Empty, uninitialised.filename);
             Assert.AreEqual(string.Empty, uninitialised.relativePath);
             Assert.AreEqual(string.Empty, uninitialised.GetCallingMethod());
-            Assert.AreEqual(string.Empty, uninitialised.name);
+            Assert.AreEqual(string.Empty, uninitialised.description);
             Assert.False(uninitialised.isPerfCriticalContext);
         }
 


### PR DESCRIPTION
This PR improves the call hierarchy building and visualization performance. Specifically, it solves the following problems:
- Building code diagnostics call tree can be very expensive on large projects. Taking several hours in some cases due to recomputing sub-hierarchies even though they have already been computed before. This is now cached.
- Drawing the UI can also take a long time due to call tree traversal to find if any node if a hot-path (_critical_). This property is now computed only once and propagated to the root of the hierarchy.
- There is a redundant node (first child of the root). This was removed and a lot of code simplified.

This PR also adds call-tree specific test coverage.

As a result, analysis on large projects should only take minutes and there should not be any more lag in the UI.

cc @xdegtyarev