### PR TITLE
Export Shader Variants as Shader Variant Collection

### DIFF
--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -430,9 +430,9 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                     shaderVariantData.shaderType.ToString(),
                     shaderVariantData.passType.ToString(),
                     shaderVariantData.passName,
-                    CombineStrings(shaderVariantData.keywords),
-                    CombineStrings(shaderVariantData.platformKeywords),
-                    CombineStrings(shaderVariantData.requirements.Select(r => r.ToString()).ToArray())
+                    CombineKeywords(shaderVariantData.keywords),
+                    CombineKeywords(shaderVariantData.platformKeywords),
+                    CombineKeywords(shaderVariantData.requirements.Select(r => r.ToString()).ToArray())
                 });
 
                 onIssueFound(issue);
@@ -507,7 +507,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 var pass = parts[1];
                 var stage = parts[2];
                 var keywordsString = parts[3];
-                var keywords = StringToKeywords(keywordsString, " ");
+                var keywords = SplitKeywords(keywordsString, " ");
 
                 // fix-up stage to be consistent with built variants stage
                 if (k_StageNameMap.ContainsKey(stage))
@@ -547,7 +547,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 var stage = builtVariant.GetCustomProperty(ShaderVariantProperty.Stage);
                 var passName = builtVariant.GetCustomProperty(ShaderVariantProperty.PassName);
                 var keywordsString = builtVariant.GetCustomProperty(ShaderVariantProperty.Keywords);
-                var keywords = StringToKeywords(keywordsString);
+                var keywords = SplitKeywords(keywordsString);
                 var isVariantCompiled = false;
 
                 if (compiledVariants.ContainsKey(shaderName))
@@ -625,14 +625,14 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
 #endif
 
-        static string[] StringToKeywords(string keywordsString, string separator = null)
+        static string[] SplitKeywords(string keywordsString, string separator = null)
         {
             if (keywordsString.Equals(k_NoKeywords))
                 return new string[] {};
             return Formatting.SplitStrings(keywordsString, separator);
         }
 
-        static string CombineStrings(string[] strings, string separator = null)
+        static string CombineKeywords(string[] strings, string separator = null)
         {
             if (strings.Length > 0)
                 return Formatting.CombineStrings(strings, separator);

--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -486,6 +486,28 @@ namespace Unity.ProjectAuditor.Editor.Auditors
 
 #endif
 
+        public static void ExportSVC(string svcName, string path, ProjectIssue[] variants)
+        {
+            var svc = new ShaderVariantCollection();
+            svc.name = svcName;
+
+            foreach (var issue in variants)
+            {
+                var shader = Shader.Find(issue.GetProperty(PropertyType.Description));
+                var passType = issue.GetCustomProperty(ShaderVariantProperty.PassType);
+                var keywords = SplitKeywords(issue.GetCustomProperty(ShaderVariantProperty.Keywords));
+
+                if (shader != null && !passType.Equals(string.Empty) && keywords.Length > 0)
+                {
+                    var shaderVariant = new ShaderVariantCollection.ShaderVariant();
+                    shaderVariant.shader = shader;
+                    shaderVariant.passType = (UnityEngine.Rendering.PassType)Enum.Parse(typeof(UnityEngine.Rendering.PassType), passType);
+                    shaderVariant.keywords = keywords;
+                    svc.Add(shaderVariant);
+                }
+            }
+            AssetDatabase.CreateAsset(svc, path);
+        }
 
         public static ParseLogResult ParsePlayerLog(string logFile, ProjectIssue[] builtVariants, IProgress progress = null)
         {

--- a/Editor/UI/Framework/AnalysisView.cs
+++ b/Editor/UI/Framework/AnalysisView.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Unity.ProjectAuditor.Editor.Auditors;
 using Unity.ProjectAuditor.Editor.CodeAnalysis;
 using Unity.ProjectAuditor.Editor.Utils;
 using UnityEditor;
@@ -535,7 +534,6 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
         {
             "All",
             "Filtered",
-            "SVC",
             "Selected"
         };
 

--- a/Editor/UI/Framework/Unity.ProjectAuditor.Editor.UI.Framework.api
+++ b/Editor/UI/Framework/Unity.ProjectAuditor.Editor.UI.Framework.api
@@ -54,6 +54,7 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
         public virtual void DrawFoldouts(Unity.ProjectAuditor.Editor.ProjectIssue[] selectedIssues);
         public void DrawInfo();
         public virtual void DrawTextSearch();
+        protected virtual void Export(System.Func<Unity.ProjectAuditor.Editor.ProjectIssue, bool> predicate = default(System.Func<Unity.ProjectAuditor.Editor.ProjectIssue, bool>));
         protected Unity.ProjectAuditor.Editor.ProjectIssue[] GetIssues();
         protected string GetPrefKey(string key);
         public bool IsValid();

--- a/Editor/UI/ShaderVariantsView.cs
+++ b/Editor/UI/ShaderVariantsView.cs
@@ -42,6 +42,7 @@ The number of Variants contributes to the build size, however, there might be Va
         const string k_Ok = "Ok";
         const string k_Yes = "Yes";
         const string k_No = "No";
+        const string k_LogShaderCompilation = "Log Shader Compilation (requires Build&Run)";
 
         bool m_ShowCompiledVariants = true;
         bool m_ShowUncompiledVariants = true;
@@ -173,7 +174,7 @@ The number of Variants contributes to the build size, however, there might be Va
                     : k_PlayerLogParsingUnsupported, SharedStyles.TextArea);
 
                 if (GraphicsSettingsProxy.logShaderCompilationSupported)
-                    GraphicsSettingsProxy.logWhenShaderIsCompiled = EditorGUILayout.Toggle("Log Shader Compilation (requires Build&Run)", GraphicsSettingsProxy.logWhenShaderIsCompiled, GUILayout.Width(320));
+                    GraphicsSettingsProxy.logWhenShaderIsCompiled = EditorGUILayout.Toggle(k_LogShaderCompilation, GraphicsSettingsProxy.logWhenShaderIsCompiled, GUILayout.Width(320));
 
                 var evt = Event.current;
 

--- a/Editor/UI/ShaderVariantsView.cs
+++ b/Editor/UI/ShaderVariantsView.cs
@@ -174,7 +174,12 @@ The number of Variants contributes to the build size, however, there might be Va
                     : k_PlayerLogParsingUnsupported, SharedStyles.TextArea);
 
                 if (GraphicsSettingsProxy.logShaderCompilationSupported)
-                    GraphicsSettingsProxy.logWhenShaderIsCompiled = EditorGUILayout.Toggle(k_LogShaderCompilation, GraphicsSettingsProxy.logWhenShaderIsCompiled, GUILayout.Width(320));
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    EditorGUILayout.LabelField(k_LogShaderCompilation, GUILayout.Width(270));
+                    GraphicsSettingsProxy.logWhenShaderIsCompiled = EditorGUILayout.Toggle(GraphicsSettingsProxy.logWhenShaderIsCompiled);
+                    EditorGUILayout.EndHorizontal();
+                }
 
                 var evt = Event.current;
 

--- a/Editor/UI/ShaderVariantsView.cs
+++ b/Editor/UI/ShaderVariantsView.cs
@@ -43,7 +43,9 @@ The number of Variants contributes to the build size, however, there might be Va
         const string k_Yes = "Yes";
         const string k_No = "No";
         const string k_LogShaderCompilation = "Log Shader Compilation (requires Build&Run)";
+        const string k_ExportAsVariantCollection = "Export as Shader Variant Collection";
 
+        bool m_ExportAsVariantCollection = true;
         bool m_ShowCompiledVariants = true;
         bool m_ShowUncompiledVariants = true;
 
@@ -181,6 +183,11 @@ The number of Variants contributes to the build size, however, there might be Va
                     EditorGUILayout.EndHorizontal();
                 }
 
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.LabelField(k_ExportAsVariantCollection, GUILayout.Width(270));
+                m_ExportAsVariantCollection = EditorGUILayout.Toggle(m_ExportAsVariantCollection);
+                EditorGUILayout.EndHorizontal();
+
                 var evt = Event.current;
 
                 switch (evt.type)
@@ -209,6 +216,30 @@ The number of Variants contributes to the build size, however, there might be Va
             foreach (var path in paths)
             {
                 ParsePlayerLog(path);
+            }
+        }
+
+        protected override void Export(Func<ProjectIssue, bool> predicate = null)
+        {
+            if (!m_ExportAsVariantCollection)
+            {
+                base.Export(predicate);
+                return;
+            }
+
+            var path = EditorUtility.SaveFilePanelInProject("Save to SVC file", "NewShaderVariants.shadervariants",
+                "shadervariants", "Save SVC");
+
+            var svcName = Path.GetFileNameWithoutExtension(path);
+            if (path.Length != 0)
+            {
+                var variants = m_Issues.Where(issue => predicate == null || predicate(issue));
+
+                ShadersModule.ExportSVC(svcName, path, variants.ToArray());
+
+                EditorUtility.RevealInFinder(path);
+
+                s_ExportDirectory = Path.GetDirectoryName(path);
             }
         }
 


### PR DESCRIPTION
This PR adds support for exporting Shader Variants as Shader Variant Collection. This is an opt-in feature that requires the user to enable the "Export as Shader Variant Collection" option in the Shader Variants views.

@Anthony-Unity I slightly refactored your prototype, please have a look. It would also be great if you could give it a try. thanks!