### PR TITLE
Obsolete API detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]
 * Added support for exporting Shader Variants as [Shader Variant Collection](https://docs.unity3d.com/ScriptReference/ShaderVariantCollection.html)
+* Added support for detecting methods marked with [ObsoleteAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute)
 
 ## [0.7.5-preview] - 2022-04-20
 * Added groups support to Shaders view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]
 * Added support for exporting Shader Variants as [Shader Variant Collection](https://docs.unity3d.com/ScriptReference/ShaderVariantCollection.html)
-* Added support for detecting methods marked with [ObsoleteAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute)
+* Added support for detecting calls to methods marked with [ObsoleteAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute)
 
 ## [0.7.5-preview] - 2022-04-20
 * Added groups support to Shaders view

--- a/Editor/CodeAnalysis/MonoCecilHelper.cs
+++ b/Editor/CodeAnalysis/MonoCecilHelper.cs
@@ -19,5 +19,14 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
                     typeDefs.AddRange(AggregateAllTypeDefinitions(typeDefinition.NestedTypes));
             return typeDefs;
         }
+
+        public static CustomAttribute GetCustomAttribute<T>(IMemberDefinition memberDefinition)
+        {
+            if (!memberDefinition.HasCustomAttributes)
+                return null;
+
+            var attrNameHash = typeof(T).FullName.GetHashCode();
+            return memberDefinition.CustomAttributes.SingleOrDefault(attr => attr.AttributeType.FullName.GetHashCode() == attrNameHash);
+        }
     }
 }

--- a/Editor/InstructionAnalyzers/ObsoleteMethodCallAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/ObsoleteMethodCallAnalyzer.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Unity.ProjectAuditor.Editor.Auditors;
+using Unity.ProjectAuditor.Editor.CodeAnalysis;
+using Unity.ProjectAuditor.Editor.Utils;
+using UnityEngine;
+
+namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
+{
+    public class ObsoleteMethodCallAnalyzer : IInstructionAnalyzer
+    {
+        static readonly ProblemDescriptor k_ObsoleteMethodCallDescriptor = new ProblemDescriptor
+        (
+            102005,
+            "Obsolete method call",
+            Area.Info,
+            "This method is marked as obsolete",
+            "Do not call this method if possible"
+        );
+
+        public void Initialize(ProjectAuditorModule module)
+        {
+        }
+
+        public IEnumerable<OpCode> GetOpCodes()
+        {
+            yield return OpCodes.Call;
+            yield return OpCodes.Callvirt;
+        }
+
+        public ProjectIssue Analyze(MethodDefinition methodDefinition, Instruction inst)
+        {
+            var calleeReference = (MethodReference)inst.Operand;
+            try
+            {
+                var calleeDefinition = calleeReference.Resolve();
+                var attr = MonoCecilHelper.GetCustomAttribute<ObsoleteAttribute>(calleeDefinition);
+                if (attr != null)
+                {
+                    var desc = k_ObsoleteMethodCallDescriptor;
+                    var description = string.Format("Call to '{0}' obsolete method", calleeDefinition.Name);
+                    var isError = false;
+
+                    if (attr.HasConstructorArguments && attr.ConstructorArguments.Count > 0)
+                    {
+                        var stringArguments = attr.ConstructorArguments.Where(a => a.Value is string).ToArray();
+                        if (stringArguments.Length > 0)
+                        {
+                            desc = new ProblemDescriptor
+                            (
+                                k_ObsoleteMethodCallDescriptor.id,
+                                k_ObsoleteMethodCallDescriptor.description,
+                                k_ObsoleteMethodCallDescriptor.GetAreas(),
+                                k_ObsoleteMethodCallDescriptor.problem,
+                                stringArguments[0].Value as string
+                            );
+                        }
+                        var boolArguments = attr.ConstructorArguments.Where(a => a.Value is bool).ToArray();
+                        isError = (boolArguments.Length > 0) && (bool)boolArguments[0].Value;
+                    }
+
+                    var projectIssue = new ProjectIssue
+                    (
+                        desc,
+                        description,
+                        IssueCategory.Code
+                    )
+                    {
+                        severity = isError ? Rule.Severity.Error : Rule.Severity.Warning
+                    };
+
+                    return projectIssue;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(e);
+            }
+            return null;
+        }
+    }
+}

--- a/Editor/InstructionAnalyzers/ObsoleteMethodCallAnalyzer.cs.meta
+++ b/Editor/InstructionAnalyzers/ObsoleteMethodCallAnalyzer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0260824cebba492fbfb335f95a24f031
+timeCreated: 1650868153

--- a/Editor/Modules/CodeModule.cs
+++ b/Editor/Modules/CodeModule.cs
@@ -81,7 +81,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             category = IssueCategory.Code,
             properties = new[]
             {
-                new PropertyDefinition { type = PropertyType.Severity},
+                new PropertyDefinition { type = PropertyType.Severity, longName = "Severity"},
                 new PropertyDefinition { type = PropertyType.Description, name = "Issue", longName = "Issue description"},
                 new PropertyDefinition { type = PropertyType.CriticalContext, format = PropertyFormat.Bool, name = "Critical", longName = "Critical code path"},
                 new PropertyDefinition { type = PropertyType.Area, name = "Area", longName = "The area the issue might have an impact on"},

--- a/Editor/Modules/CodeModule.cs
+++ b/Editor/Modules/CodeModule.cs
@@ -52,6 +52,15 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             severity = Rule.Severity.Error
         };
 
+        static readonly ProblemDescriptor k_ObsoleteMethodDescriptor = new ProblemDescriptor
+            (
+            102005,
+            "Obsolete method",
+            Area.Info,
+            "This method is obsolete",
+            "Do not use if possible"
+            );
+
         const int k_CompilerMessageFirstId = 800000;
 
         static readonly IssueLayout k_AssemblyLayout = new IssueLayout
@@ -72,6 +81,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             category = IssueCategory.Code,
             properties = new[]
             {
+                new PropertyDefinition { type = PropertyType.Severity},
                 new PropertyDefinition { type = PropertyType.Description, name = "Issue", longName = "Issue description"},
                 new PropertyDefinition { type = PropertyType.CriticalContext, format = PropertyFormat.Bool, name = "Critical", longName = "Critical code path"},
                 new PropertyDefinition { type = PropertyType.Area, name = "Area", longName = "The area the issue might have an impact on"},
@@ -303,6 +313,37 @@ namespace Unity.ProjectAuditor.Editor.Auditors
             {
                 perfCriticalContext = perfCriticalContext
             };
+
+            var obsoleteAttribute =
+                caller.CustomAttributes.FirstOrDefault(a =>
+                    a.AttributeType.FullName.Equals("System.ObsoleteAttribute"));
+
+            if (obsoleteAttribute != null)
+            {
+                var description = string.Format("Method '{0}' is obsolete", caller.Name);
+                var stringArguments = obsoleteAttribute.ConstructorArguments.Where(a => a.Value is string).ToArray();
+                if (stringArguments.Length > 0)
+                    description += ": " + stringArguments[0].Value;
+
+                var boolArguments = obsoleteAttribute.ConstructorArguments.Where(a => a.Value is bool).ToArray();
+                var isError = (boolArguments.Length > 0) && (bool)boolArguments[0].Value;
+
+                var projectIssue = new ProjectIssue
+                    (
+                    k_ObsoleteMethodDescriptor,
+                    description,
+                    IssueCategory.Code
+                    )
+                {
+                    severity = isError ? Rule.Severity.Error : Rule.Severity.Warning
+                };
+
+                projectIssue.dependencies = callerNode; // set root
+                //  projectIssue.location = location;
+                projectIssue.SetCustomProperties(new string[(int)CodeProperty.Num] {assemblyInfo.name});
+
+                onIssueFound(projectIssue);
+            }
 
             foreach (var inst in caller.Body.Instructions.Where(i => m_OpCodes.Contains(i.OpCode)))
             {

--- a/Editor/Utils/Exporter.cs
+++ b/Editor/Utils/Exporter.cs
@@ -26,7 +26,9 @@ namespace Unity.ProjectAuditor.Editor.Utils
             var stringBuilder = new StringBuilder();
             for (int i = 0; i < m_Layout.properties.Length; i++)
             {
-                stringBuilder.Append(m_Layout.properties[i].name);
+                var property = m_Layout.properties[i];
+                var name = property.name != null ? property.name : property.longName;
+                stringBuilder.Append(name);
                 if (i + 1 < m_Layout.properties.Length)
                     stringBuilder.Append(",");
             }

--- a/Tests/Editor/ObsoleteMethodTests.cs
+++ b/Tests/Editor/ObsoleteMethodTests.cs
@@ -10,24 +10,19 @@ namespace Unity.ProjectAuditor.EditorTests
     class ObsoleteMethodTests
     {
         TempAsset m_TempAssetWarning;
-        TempAsset m_TempAssetError;
 
         [SetUp]
         public void SetUp()
         {
-            m_TempAssetWarning = new TempAsset("ClassWithObsoleteMethodWarning.cs", @"
-class ClassWithObsoleteMethodWarning
+            m_TempAssetWarning = new TempAsset("ClassWithCallToObsoleteMethod.cs", @"
+class ClassWithCallToObsoleteMethod
 {
-    [System.Obsolete(""Try not to use me"")]
-    void LegacyMethod()
-    {}
-}"
-            );
+    void Caller()
+    {
+        LegacyMethod();
+    }
 
-            m_TempAssetError = new TempAsset("ClassWithObsoleteMethodError.cs", @"
-class ClassWithObsoleteMethodError
-{
-    [System.Obsolete(""Do not use me, ever!"", true)]
+    [System.Obsolete(""Try not to use me"")]
     void LegacyMethod()
     {}
 }"
@@ -54,30 +49,11 @@ class ClassWithObsoleteMethodError
 
             Assert.AreEqual(Rule.Severity.Default, diag.descriptor.severity);
             Assert.AreEqual(Rule.Severity.Warning, diag.severity);
-            Assert.AreEqual("Obsolete method", diag.descriptor.description);
+            Assert.AreEqual("Obsolete method call", diag.descriptor.description);
 
-            Assert.AreEqual("Method 'LegacyMethod' is obsolete: Try not to use me", diag.description);
-            Assert.AreEqual("System.Void ClassWithObsoleteMethodWarning::LegacyMethod()", diag.GetContext());
-        }
-
-        [Test]
-        public void CodeAnalysis_ObsoleteMethod_ErrorIsReported()
-        {
-            var diagnostics = Utility.AnalyzeAndFindAssetIssues(m_TempAssetError);
-
-            Assert.AreEqual(1, diagnostics.Length);
-
-            var diag = diagnostics[0];
-
-            Assert.NotNull(diag);
-            Assert.NotNull(diag.descriptor);
-
-            Assert.AreEqual(Rule.Severity.Default, diag.descriptor.severity);
-            Assert.AreEqual(Rule.Severity.Error, diag.severity);
-            Assert.AreEqual("Obsolete method", diag.descriptor.description);
-
-            Assert.AreEqual("Method 'LegacyMethod' is obsolete: Do not use me, ever!", diag.description);
-            Assert.AreEqual("System.Void ClassWithObsoleteMethodError::LegacyMethod()", diag.GetContext());
+            Assert.AreEqual("Call to 'LegacyMethod' obsolete method: Try not to use me", diag.description);
+            Assert.AreEqual("System.Void ClassWithCallToObsoleteMethod::Caller()", diag.GetContext());
+            Assert.AreEqual(6, diag.line);
         }
     }
 }

--- a/Tests/Editor/ObsoleteMethodTests.cs
+++ b/Tests/Editor/ObsoleteMethodTests.cs
@@ -9,12 +9,13 @@ namespace Unity.ProjectAuditor.EditorTests
 {
     class ObsoleteMethodTests
     {
-        TempAsset m_TempAssetWarning;
+        TempAsset m_TempAssetObsoleteMethod;
+        TempAsset m_TempAssetObsoleteMethodDefaultMessage;
 
         [SetUp]
         public void SetUp()
         {
-            m_TempAssetWarning = new TempAsset("ClassWithCallToObsoleteMethod.cs", @"
+            m_TempAssetObsoleteMethod = new TempAsset("ClassWithCallToObsoleteMethod.cs", @"
 class ClassWithCallToObsoleteMethod
 {
     void Caller()
@@ -23,6 +24,20 @@ class ClassWithCallToObsoleteMethod
     }
 
     [System.Obsolete(""Try not to use me"")]
+    void LegacyMethod()
+    {}
+}"
+            );
+
+            m_TempAssetObsoleteMethodDefaultMessage = new TempAsset("ClassWithCallToObsoleteMethodWithDefaultMessage.cs", @"
+class ClassWithCallToObsoleteMethodWithDefaultMessage
+{
+    void Caller()
+    {
+        LegacyMethod();
+    }
+
+    [System.Obsolete()]
     void LegacyMethod()
     {}
 }"
@@ -38,7 +53,7 @@ class ClassWithCallToObsoleteMethod
         [Test]
         public void CodeAnalysis_ObsoleteMethod_WarningIsReported()
         {
-            var diagnostics = Utility.AnalyzeAndFindAssetIssues(m_TempAssetWarning);
+            var diagnostics = Utility.AnalyzeAndFindAssetIssues(m_TempAssetObsoleteMethod);
 
             Assert.AreEqual(1, diagnostics.Length);
 
@@ -50,9 +65,34 @@ class ClassWithCallToObsoleteMethod
             Assert.AreEqual(Rule.Severity.Default, diag.descriptor.severity);
             Assert.AreEqual(Rule.Severity.Warning, diag.severity);
             Assert.AreEqual("Obsolete method call", diag.descriptor.description);
+            Assert.AreEqual("This method is marked as obsolete", diag.descriptor.problem);
+            Assert.AreEqual("Try not to use me", diag.descriptor.solution);
 
-            Assert.AreEqual("Call to 'LegacyMethod' obsolete method: Try not to use me", diag.description);
+            Assert.AreEqual("Call to 'LegacyMethod' obsolete method", diag.description);
             Assert.AreEqual("System.Void ClassWithCallToObsoleteMethod::Caller()", diag.GetContext());
+            Assert.AreEqual(6, diag.line);
+        }
+
+        [Test]
+        public void CodeAnalysis_ObsoleteMethodWithDefaultMessage_WarningIsReported()
+        {
+            var diagnostics = Utility.AnalyzeAndFindAssetIssues(m_TempAssetObsoleteMethodDefaultMessage);
+
+            Assert.AreEqual(1, diagnostics.Length);
+
+            var diag = diagnostics[0];
+
+            Assert.NotNull(diag);
+            Assert.NotNull(diag.descriptor);
+
+            Assert.AreEqual(Rule.Severity.Default, diag.descriptor.severity);
+            Assert.AreEqual(Rule.Severity.Warning, diag.severity);
+            Assert.AreEqual("Obsolete method call", diag.descriptor.description);
+            Assert.AreEqual("This method is marked as obsolete", diag.descriptor.problem);
+            Assert.AreEqual("Do not call this method if possible", diag.descriptor.solution);
+
+            Assert.AreEqual("Call to 'LegacyMethod' obsolete method", diag.description);
+            Assert.AreEqual("System.Void ClassWithCallToObsoleteMethodWithDefaultMessage::Caller()", diag.GetContext());
             Assert.AreEqual(6, diag.line);
         }
     }

--- a/Tests/Editor/ObsoleteMethodTests.cs
+++ b/Tests/Editor/ObsoleteMethodTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor;
+using Unity.ProjectAuditor.Editor.CodeAnalysis;
+using Unity.ProjectAuditor.Editor.Utils;
+
+namespace Unity.ProjectAuditor.EditorTests
+{
+    class ObsoleteMethodTests
+    {
+        TempAsset m_TempAssetWarning;
+        TempAsset m_TempAssetError;
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_TempAssetWarning = new TempAsset("ClassWithObsoleteMethodWarning.cs", @"
+class ClassWithObsoleteMethodWarning
+{
+    [System.Obsolete(""Try not to use me"")]
+    void LegacyMethod()
+    {}
+}"
+            );
+
+            m_TempAssetError = new TempAsset("ClassWithObsoleteMethodError.cs", @"
+class ClassWithObsoleteMethodError
+{
+    [System.Obsolete(""Do not use me, ever!"", true)]
+    void LegacyMethod()
+    {}
+}"
+            );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TempAsset.Cleanup();
+        }
+
+        [Test]
+        public void CodeAnalysis_ObsoleteMethod_WarningIsReported()
+        {
+            var diagnostics = Utility.AnalyzeAndFindAssetIssues(m_TempAssetWarning);
+
+            Assert.AreEqual(1, diagnostics.Length);
+
+            var diag = diagnostics[0];
+
+            Assert.NotNull(diag);
+            Assert.NotNull(diag.descriptor);
+
+            Assert.AreEqual(Rule.Severity.Default, diag.descriptor.severity);
+            Assert.AreEqual(Rule.Severity.Warning, diag.severity);
+            Assert.AreEqual("Obsolete method", diag.descriptor.description);
+
+            Assert.AreEqual("Method 'LegacyMethod' is obsolete: Try not to use me", diag.description);
+            Assert.AreEqual("System.Void ClassWithObsoleteMethodWarning::LegacyMethod()", diag.GetContext());
+        }
+
+        [Test]
+        public void CodeAnalysis_ObsoleteMethod_ErrorIsReported()
+        {
+            var diagnostics = Utility.AnalyzeAndFindAssetIssues(m_TempAssetError);
+
+            Assert.AreEqual(1, diagnostics.Length);
+
+            var diag = diagnostics[0];
+
+            Assert.NotNull(diag);
+            Assert.NotNull(diag.descriptor);
+
+            Assert.AreEqual(Rule.Severity.Default, diag.descriptor.severity);
+            Assert.AreEqual(Rule.Severity.Error, diag.severity);
+            Assert.AreEqual("Obsolete method", diag.descriptor.description);
+
+            Assert.AreEqual("Method 'LegacyMethod' is obsolete: Do not use me, ever!", diag.description);
+            Assert.AreEqual("System.Void ClassWithObsoleteMethodError::LegacyMethod()", diag.GetContext());
+        }
+    }
+}

--- a/Tests/Editor/ObsoleteMethodTests.cs.meta
+++ b/Tests/Editor/ObsoleteMethodTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ba2e2d5f4f028e468a3c049181a2a6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/ProjectReportTests.cs
+++ b/Tests/Editor/ProjectReportTests.cs
@@ -97,9 +97,9 @@ class MyClass : MonoBehaviour
             using (var file = new StreamReader(path))
             {
                 var line = file.ReadLine();
-                Assert.AreEqual("Issue,Critical,Area,Filename,Assembly", line);
+                Assert.AreEqual("Severity,Issue,Critical,Area,Filename,Assembly", line);
 
-                var expectedIssueLine = "\"UnityEngine.Camera.allCameras\",\"True\",\"Memory\",\"MyClass.cs:7\",\"Assembly-CSharp\"";
+                var expectedIssueLine = "\"Default\",\"UnityEngine.Camera.allCameras\",\"True\",\"Memory\",\"MyClass.cs:7\",\"Assembly-CSharp\"";
                 while (file.Peek() >= 0)
                 {
                     line = file.ReadLine();
@@ -124,9 +124,9 @@ class MyClass : MonoBehaviour
             using (var file = new StreamReader(path))
             {
                 var line = file.ReadLine();
-                Assert.AreEqual("Issue,Critical,Area,Filename,Assembly", line);
+                Assert.AreEqual("Severity,Issue,Critical,Area,Filename,Assembly", line);
 
-                var expectedIssueLine = "\"Conversion from value type 'Int32' to ref type\",\"True\",\"Memory\",\"MyClass.cs:7\",\"Assembly-CSharp\"";
+                var expectedIssueLine = "\"Default\",\"Conversion from value type 'Int32' to ref type\",\"True\",\"Memory\",\"MyClass.cs:7\",\"Assembly-CSharp\"";
                 while (file.Peek() >= 0)
                 {
                     line = file.ReadLine();


### PR DESCRIPTION
This PR introduces support for detecting calls to methods marked with [ObsoleteAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute).

Note that all reported ObsoleteAttribute diagnostic issues will be reported as either Warnings or Errors. Depending on the attribute constructor arguments.

![obsolete-method-v2](https://user-images.githubusercontent.com/12098182/164749482-b20b45f0-4144-4a69-8b68-272a1b0830ac.PNG)

Note this was a feature request by @jed-unity3d