### PR TITLE
Add graphics tier support to variants

### DIFF
--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -33,6 +33,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
     {
         Compiled = 0,
         Platform,
+        Tier,
         Stage,
         PassType,
         PassName,
@@ -109,6 +110,7 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 new PropertyDefinition { type = PropertyType.Description, name = "Shader Name"},
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(ShaderVariantProperty.Compiled), format = PropertyFormat.Bool, name = "Compiled", longName = "Compiled at runtime by the player" },
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(ShaderVariantProperty.Platform), format = PropertyFormat.String, name = "Graphics API" },
+                new PropertyDefinition { type = PropertyTypeUtil.FromCustom(ShaderVariantProperty.Tier), format = PropertyFormat.String, name = "Tier" },
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(ShaderVariantProperty.Stage), format = PropertyFormat.String, name = "Stage" },
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(ShaderVariantProperty.PassType), format = PropertyFormat.String, name = "Pass Type" },
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(ShaderVariantProperty.PassName), format = PropertyFormat.String, name = "Pass Name" },
@@ -426,8 +428,9 @@ namespace Unity.ProjectAuditor.Editor.Auditors
                 {
                     k_NoRuntimeData,
                     shaderVariantData.compilerPlatform,
-                    shaderVariantData.shaderType.ToString(),
-                    shaderVariantData.passType.ToString(),
+                    shaderVariantData.graphicsTier,
+                    shaderVariantData.shaderType,
+                    shaderVariantData.passType,
                     shaderVariantData.passName,
                     CombineKeywords(shaderVariantData.keywords),
                     CombineKeywords(shaderVariantData.platformKeywords),

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -337,14 +337,15 @@ namespace Unity.ProjectAuditor.Editor.Auditors
     public enum ShaderVariantProperty
     {
         public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Compiled = 0;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Keywords = 5;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Num = 8;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PassName = 4;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PassType = 3;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Keywords = 6;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Num = 9;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PassName = 5;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PassType = 4;
         public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Platform = 1;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PlatformKeywords = 6;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Requirements = 7;
-        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Stage = 2;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty PlatformKeywords = 7;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Requirements = 8;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Stage = 3;
+        public const Unity.ProjectAuditor.Editor.Auditors.ShaderVariantProperty Tier = 2;
         public int value__;
     }
 }

--- a/Tests/Editor/ShadersAnalysisTests.cs
+++ b/Tests/Editor/ShadersAnalysisTests.cs
@@ -373,6 +373,8 @@ Shader ""Custom/MyEditorShader""
             var variants = issues.Where(i => i.description.Equals(k_ShaderName)).ToArray();
             Assert.Positive(variants.Length);
 
+            Assert.True(variants.All(v => v.GetCustomProperty(ShaderVariantProperty.Tier).Equals("Tier1")));
+
             var shaderCompilerPlatforms = variants.Select(v => v.GetCustomProperty(ShaderVariantProperty.Platform)).Distinct();
             var compilerPlatformNames = ShaderUtilProxy.GetCompilerPlatformNames();
 


### PR DESCRIPTION
**Problem**
Some reported variants have the same properties (stage, pass name/type, keywords, etc...) so to the user it looks the same variant is reported multiple times. This is due to variants built for different Graphics Tiers.

**Solution**
Add Tier information to reported variants