### PR TITLE
Id as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added user preferences
 * Added group size/time properties
 * Added support for analyzing all compiled Editor assemblies
+* Changed descriptor ID to use a string instead of an integer
 * Fixed Diagnostic Rules serialization
 * Fixed *Home* page *NullReferenceException* on Build
 * Improved issue creation code-readability by using *ProjectIssueBuilder*

--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -1,7 +1,7 @@
 {
     "Items": [
         {
-            "id": "101000",
+            "id": "CD0000",
             "type": "UnityEngine.Camera",
             "method": "main",
             "areas": ["CPU"],
@@ -10,7 +10,7 @@
             "maximumVersion": "2019.4.8"
         },
         {
-            "id": "101001",
+            "id": "CD0001",
             "type": "UnityEngine.WebCamTexture",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -18,7 +18,7 @@
             "solution": "Use WebCamTexture.GetPixels32() instead."
         },
         {
-            "id": "101002",
+            "id": "CD0002",
             "type": "UnityEngine.WebCamTexture",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -26,7 +26,7 @@
             "solution": "Ensure that you pass an array of Color32[] to this API method for it to fill out, to avoid creating a new array every time the method is called."
         },
         {
-            "id": "101003",
+            "id": "CD0003",
             "type": "UnityEngine.GeometryUtility",
             "method": "CalculateFrustumPlanes",
             "areas": ["Memory"],
@@ -34,7 +34,7 @@
             "solution": "Ensure that you use the CalculateFrustumPlanes(Matrix4x4 worldToProjectionMatrix, Plane[] planes) version of this API method, in order to be able to pass a pre-allocated Array of Planes."
         },
         {
-            "id": "101004",
+            "id": "CD0004",
             "type": "UnityEngine.Resources",
             "method": "FindObjectsOfTypeAll",
             "areas": ["Memory"],
@@ -42,7 +42,7 @@
             "solution": "Use Resources.FindObjectsOfTypeNonAlloc() instead."
         },
         {
-            "id": "101005",
+            "id": "CD0005",
             "type": "UnityEngine.Texture2D",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -50,7 +50,7 @@
             "solution": "Use Texture2D.GetRawTextureData() instead. This method returns a NativeArray of pixel data, and so does not allocate managed memory."
         },
         {
-            "id": "101006",
+            "id": "CD0006",
             "type": "UnityEngine.Texture2D",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -58,7 +58,7 @@
             "solution": "Use Texture2D.GetRawTextureData() instead. This method returns a NativeArray of pixel data, and so does not allocate managed memory."
         },
         {
-            "id": "101007",
+            "id": "CD0007",
             "type": "UnityEngine.Rigidbody",
             "method": "SweepTestAll",
             "areas": ["Memory"],
@@ -66,7 +66,7 @@
             "solution": "Use Rigidbody.SweepTestNonAlloc() instead."
         },
         {
-            "id": "101008",
+            "id": "CD0008",
             "type": "UnityEngine.Physics",
             "method": "RaycastAll",
             "areas": ["Memory"],
@@ -74,7 +74,7 @@
             "solution": "Use Physics.RaycastNonAlloc() instead."
         },
         {
-            "id": "101009",
+            "id": "CD0009",
             "type": "UnityEngine.Physics",
             "method": "CapsuleCastAll",
             "areas": ["Memory"],
@@ -82,7 +82,7 @@
             "solution": "Use Physics.CapsuleCastNonAlloc() instead."
         },
         {
-            "id": "101010",
+            "id": "CD0010",
             "type": "UnityEngine.Physics",
             "method": "SphereCastAll",
             "areas": ["Memory"],
@@ -90,7 +90,7 @@
             "solution": "Use Physics.SphereCastNonAlloc() instead."
         },
         {
-            "id": "101011",
+            "id": "CD0011",
             "type": "UnityEngine.Physics",
             "method": "BoxCastAll",
             "areas": ["Memory"],
@@ -98,7 +98,7 @@
             "solution": "Use Physics.BoxCastNonAlloc() instead."
         },
         {
-            "id": "101012",
+            "id": "CD0012",
             "type": "UnityEngine.Physics",
             "method": "OverlapCapsule",
             "areas": ["Memory"],
@@ -106,7 +106,7 @@
             "solution": "Use Physics.OverlapCapsuleNonAlloc() instead."
         },
         {
-            "id": "101013",
+            "id": "CD0013",
             "type": "UnityEngine.Physics",
             "method": "OverlapSphere",
             "areas": ["Memory"],
@@ -114,7 +114,7 @@
             "solution": "Use Physics.OverlapSphereNonAlloc() instead."
         },
         {
-            "id": "101014",
+            "id": "CD0014",
             "type": "UnityEngine.Physics",
             "method": "OverlapBox",
             "areas": ["Memory"],
@@ -122,7 +122,7 @@
             "solution": "Use Physics.OverlapBoxNonAlloc() instead."
         },
         {
-            "id": "101015",
+            "id": "CD0015",
             "type": "UnityEngine.Physics2D",
             "method": "LinecastAll",
             "areas": ["Memory"],
@@ -130,7 +130,7 @@
             "solution": "Use Physics2D.LinecastNonAlloc() instead."
         },
         {
-            "id": "101016",
+            "id": "CD0016",
             "type": "UnityEngine.Physics2D",
             "method": "RaycastAll",
             "areas": ["Memory"],
@@ -138,7 +138,7 @@
             "solution": "Use Physics2D.RaycastNonAlloc() instead."
         },
         {
-            "id": "101017",
+            "id": "CD0017",
             "type": "UnityEngine.Physics2D",
             "method": "CircleCastAll",
             "areas": ["Memory"],
@@ -146,7 +146,7 @@
             "solution": "Use Physics2D.CircleCastNonAlloc() instead."
         },
         {
-            "id": "101018",
+            "id": "CD0018",
             "type": "UnityEngine.Physics2D",
             "method": "BoxCastAll",
             "areas": ["Memory"],
@@ -154,7 +154,7 @@
             "solution": "Use Physics2D.BoxCastNonAlloc() instead."
         },
         {
-            "id": "101019",
+            "id": "CD0019",
             "type": "UnityEngine.Physics2D",
             "method": "CapsuleCastAll",
             "areas": ["Memory"],
@@ -162,7 +162,7 @@
             "solution": "Use Physics2D.CapsuleCastNonAlloc() instead."
         },
         {
-            "id": "101020",
+            "id": "CD0020",
             "type": "UnityEngine.Physics2D",
             "method": "GetRayIntersectionAll",
             "areas": ["Memory"],
@@ -170,7 +170,7 @@
             "solution": "Use Physics2D.GetRayIntersectionNonAlloc() instead."
         },
         {
-            "id": "101021",
+            "id": "CD0021",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapPointAll",
             "areas": ["Memory"],
@@ -178,7 +178,7 @@
             "solution": "Use Physics2D.OverlapPointNonAlloc() instead."
         },
         {
-            "id": "101022",
+            "id": "CD0022",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapCircleAll",
             "areas": ["Memory"],
@@ -186,7 +186,7 @@
             "solution": "Use Physics2D.OverlapCircleNonAlloc() instead."
         },
         {
-            "id": "101023",
+            "id": "CD0023",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapBoxAll",
             "areas": ["Memory"],
@@ -194,7 +194,7 @@
             "solution": "Use Physics2D.OverlapBoxNonAlloc() instead."
         },
         {
-            "id": "101024",
+            "id": "CD0024",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapAreaAll",
             "areas": ["Memory"],
@@ -202,7 +202,7 @@
             "solution": "Use Physics2D.OverlapAreaNonAlloc() instead."
         },
         {
-            "id": "101025",
+            "id": "CD0025",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapCapsuleAll",
             "areas": ["Memory"],
@@ -210,7 +210,7 @@
             "solution": "Use Physics2D.OverlapCapsuleNonAlloc() instead."
         },
         {
-            "id": "101026",
+            "id": "CD0026",
             "type": "UnityEngine.Component",
             "method": "GetComponentsInChildren",
             "areas": ["Memory"],
@@ -218,7 +218,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInChildren() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "101027",
+            "id": "CD0027",
             "type": "UnityEngine.Component",
             "method": "GetComponentsInParent",
             "areas": ["Memory"],
@@ -226,7 +226,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInParent() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "101028",
+            "id": "CD0028",
             "type": "UnityEngine.GameObject",
             "method": "GetComponentsInChildren",
             "areas": ["Memory"],
@@ -234,7 +234,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInChildren() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "101029",
+            "id": "CD0029",
             "type": "UnityEngine.GameObject",
             "method": "GetComponentsInParent",
             "areas": ["Memory"],
@@ -242,7 +242,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInParent() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "101030",
+            "id": "CD0030",
             "type": "UnityEngine.Collider",
             "method": "OnTriggerStay",
             "areas": ["CPU"],
@@ -250,7 +250,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101031",
+            "id": "CD0031",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnTriggerStay",
             "areas": ["CPU"],
@@ -258,7 +258,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101032",
+            "id": "CD0032",
             "type": "UnityEngine.Collider2D",
             "method": "OnTriggerStay2D",
             "areas": ["CPU"],
@@ -266,7 +266,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay2D() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101033",
+            "id": "CD0033",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnTriggerStay2D",
             "areas": ["CPU"],
@@ -274,7 +274,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay2D() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101034",
+            "id": "CD0034",
             "type": "UnityEngine.Collider",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -282,7 +282,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101035",
+            "id": "CD0035",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -290,7 +290,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101036",
+            "id": "CD0036",
             "type": "UnityEngine.Rigidbody",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -298,7 +298,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "101037",
+            "id": "CD0037",
             "type": "UnityEngine.ImageConversion",
             "method": "LoadImage",
             "areas": ["Memory"],
@@ -306,7 +306,7 @@
             "solution": "If a CPU-accessible copy of the texture is not required, ensure that the markNonReadable flag passed into the method is set to true."
         },
         {
-            "id": "101039",
+            "id": "CD0039",
             "type": "UnityEngine.Renderer",
             "method": "material",
             "areas": ["GPU"],
@@ -314,23 +314,7 @@
             "solution": "If possible, use Renderer.sharedMaterial instead."
         },
         {
-            "id": "101049",
-            "type": "System.Linq",
-            "method": "*",
-            "areas": ["Memory"],
-            "problem": "Linq allocates large amounts of managed memory.",
-            "solution": "We strongly advise against using Linq in any frequently-updated code. Ban its usage from the project entirely, or confine it to initialization code and use it sparingly."
-        },
-        {
-            "id": "101050",
-            "type": "System.Reflection",
-            "method": "*",
-            "areas": ["CPU"],
-            "problem": "Reflection is slow, and not generally considered performant enough for runtime code.",
-            "solution": "Remove code which relies on reflection, or minimise its usage, particularly outside of initialization."
-        },
-        {
-            "id": "101051",
+            "id": "CD0051",
             "type": "UnityEngine.ComputeBuffer",
             "method": "GetData",
             "areas": ["CPU"],
@@ -338,7 +322,7 @@
             "solution": "Avoid reading back from ComputeBuffers if it is at all possible. If it's unavoidable, profile your project carefully and regularly to monitor the performance impact."
         },
         {
-            "id": "101052",
+            "id": "CD0052",
             "type": "UnityEngine.Texture2D",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -346,7 +330,7 @@
             "solution": "Use Texture2D.SetPixels32() or GetRawTextureData()/Apply() instead."
         },
         {
-            "id": "101053",
+            "id": "CD0053",
             "type": "UnityEngine.Texture3D",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -354,7 +338,7 @@
             "solution": "Use Texture3D.SetPixels32() instead."
         },
         {
-            "id": "101054",
+            "id": "CD0054",
             "type": "UnityEngine.Texture2DArray",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -362,7 +346,7 @@
             "solution": "Use Texture2DArray.SetPixels32() instead."
         },
         {
-            "id": "101055",
+            "id": "CD0055",
             "type": "UnityEngine.CubemapArray",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -370,7 +354,7 @@
             "solution": "Use CubemapArray.SetPixels32() instead."
         },
         {
-            "id": "101056",
+            "id": "CD0056",
             "type": "UnityEngine.GameObject",
             "method": "SendMessage",
             "areas": ["CPU"],
@@ -378,7 +362,7 @@
             "solution": "Implement a custom system to replace SendMessage - get the components you want to send messages and call methods directly on them."
         },
         {
-            "id": "101057",
+            "id": "CD0057",
             "type": "UnityEngine.Component",
             "method": "SendMessage",
             "areas": ["CPU"],
@@ -386,7 +370,7 @@
             "solution": "Implement a custom system to replace SendMessage - get the components you want to send messages and call methods directly on them."
         },
         {
-            "id": "101058",
+            "id": "CD0058",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnGUI",
             "areas": ["CPU"],
@@ -394,7 +378,7 @@
             "solution": "Remove all OnGUI() methods from the project code."
         },
         {
-            "id": "101059",
+            "id": "CD0059",
             "type": "UnityEngine.AI.NavMeshPath",
             "method": "corners",
             "areas": ["Memory"],
@@ -402,7 +386,7 @@
             "solution": "Use AI.NavMeshPath.GetCornersNonAlloc() instead"
         },
         {
-            "id": "101060",
+            "id": "CD0060",
             "type": "UnityEngine.Animator",
             "method": "parameters",
             "areas": ["Memory"],
@@ -410,7 +394,7 @@
             "solution": "Use Animator.GetParameter() instead."
         },
         {
-            "id": "101061",
+            "id": "CD0061",
             "type": "UnityEngine.Animations.ParentConstraint",
             "method": "translationOffsets",
             "areas": ["Memory"],
@@ -418,7 +402,7 @@
             "solution": "Use Animations.ParentConstraint.GetTranslationOffset() instead."
         },
         {
-            "id": "101062",
+            "id": "CD0062",
             "type": "UnityEngine.Animations.ParentConstraint",
             "method": "rotationOffsets",
             "areas": ["Memory"],
@@ -426,7 +410,7 @@
             "solution": "Use Animations.ParentConstraint.GetRotationOffset() instead."
         },
         {
-            "id": "101063",
+            "id": "CD0063",
             "type": "UnityEngine.AnimationCurve",
             "method": "keys",
             "areas": ["Memory"],
@@ -434,7 +418,7 @@
             "solution": "Use AnimationCurve.AddKey()/MoveKey()/RemoveKey() instead."
         },
         {
-            "id": "101066",
+            "id": "CD0066",
             "type": "UnityEngine.Camera",
             "method": "allCameras",
             "areas": ["Memory"],
@@ -442,7 +426,7 @@
             "solution": "Use Camera.GetAllCameras() instead."
         },
         {
-            "id": "101067",
+            "id": "CD0067",
             "type": "UnityEngine.Mesh",
             "method": "boneWeights",
             "areas": ["Memory"],
@@ -450,7 +434,7 @@
             "solution": "Use Mesh.GetAllBoneWeights() instead. This method returns a NativeArray of BoneWeight1, and so does not allocate managed memory."
         },
         {
-            "id": "101068",
+            "id": "CD0068",
             "type": "UnityEngine.Mesh",
             "method": "bindposes",
             "areas": ["Memory"],
@@ -458,7 +442,7 @@
             "solution": "Use Mesh.GetBindposes() instead."
         },
         {
-            "id": "101069",
+            "id": "CD0069",
             "type": "UnityEngine.Mesh",
             "method": "vertices",
             "areas": ["Memory"],
@@ -466,7 +450,7 @@
             "solution": "Use Mesh.GetVertices() instead."
         },
         {
-            "id": "101070",
+            "id": "CD0070",
             "type": "UnityEngine.Mesh",
             "method": "normals",
             "areas": ["Memory"],
@@ -474,7 +458,7 @@
             "solution": "Use Mesh.GetNormals() instead."
         },
         {
-            "id": "101071",
+            "id": "CD0071",
             "type": "UnityEngine.Mesh",
             "method": "tangents",
             "areas": ["Memory"],
@@ -482,7 +466,7 @@
             "solution": "Use Mesh.GetTangents() instead."
         },
         {
-            "id": "101072",
+            "id": "CD0072",
             "type": "UnityEngine.Mesh",
             "method": "uv",
             "areas": ["Memory"],
@@ -490,7 +474,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101073",
+            "id": "CD0073",
             "type": "UnityEngine.Mesh",
             "method": "uv1",
             "areas": ["Memory"],
@@ -498,7 +482,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101074",
+            "id": "CD0074",
             "type": "UnityEngine.Mesh",
             "method": "uv2",
             "areas": ["Memory"],
@@ -506,7 +490,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101075",
+            "id": "CD0075",
             "type": "UnityEngine.Mesh",
             "method": "uv3",
             "areas": ["Memory"],
@@ -514,7 +498,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101076",
+            "id": "CD0076",
             "type": "UnityEngine.Mesh",
             "method": "uv4",
             "areas": ["Memory"],
@@ -522,7 +506,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101077",
+            "id": "CD0077",
             "type": "UnityEngine.Mesh",
             "method": "uv5",
             "areas": ["Memory"],
@@ -530,7 +514,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101078",
+            "id": "CD0078",
             "type": "UnityEngine.Mesh",
             "method": "uv6",
             "areas": ["Memory"],
@@ -538,7 +522,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101079",
+            "id": "CD0079",
             "type": "UnityEngine.Mesh",
             "method": "uv7",
             "areas": ["Memory"],
@@ -546,7 +530,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101080",
+            "id": "CD0080",
             "type": "UnityEngine.Mesh",
             "method": "uv8",
             "areas": ["Memory"],
@@ -554,7 +538,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "101081",
+            "id": "CD0081",
             "type": "UnityEngine.Mesh",
             "method": "colors",
             "areas": ["Memory"],
@@ -562,7 +546,7 @@
             "solution": "Use Mesh.GetColors() instead."
         },
         {
-            "id": "101082",
+            "id": "CD0082",
             "type": "UnityEngine.Mesh",
             "method": "colors32",
             "areas": ["Memory"],
@@ -570,7 +554,7 @@
             "solution": "Use Mesh.GetColors() instead."
         },
         {
-            "id": "101083",
+            "id": "CD0083",
             "type": "UnityEngine.Mesh",
             "method": "triangles",
             "areas": ["Memory"],
@@ -578,7 +562,7 @@
             "solution": "Use Mesh.GetTriangles() instead."
         },
         {
-            "id": "101084",
+            "id": "CD0084",
             "type": "UnityEngine.Renderer",
             "method": "materials",
             "areas": ["Memory"],
@@ -586,7 +570,7 @@
             "solution": "Use Renderer.GetMaterials() instead."
         },
         {
-            "id": "101085",
+            "id": "CD0085",
             "type": "UnityEngine.Renderer",
             "method": "sharedMaterials",
             "areas": ["Memory"],
@@ -594,7 +578,7 @@
             "solution": "Use Renderer.GetSharedMaterials() instead."
         },
         {
-            "id": "101094",
+            "id": "CD0094",
             "type": "UnityEngine.Input",
             "method": "touches",
             "areas": ["Memory"],
@@ -602,7 +586,7 @@
             "solution": "Use Input.GetTouch() instead."
         },
         {
-            "id": "101095",
+            "id": "CD0095",
             "type": "UnityEngine.Input",
             "method": "accelerationEvents",
             "areas": ["Memory"],
@@ -610,7 +594,7 @@
             "solution": "Use Input.GetAccelerationEvent() instead."
         },
         {
-            "id": "101096",
+            "id": "CD0096",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "localNotifications",
             "areas": ["Memory"],
@@ -620,7 +604,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "101097",
+            "id": "CD0097",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "remoteNotifications",
             "areas": ["Memory"],
@@ -630,7 +614,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "101100",
+            "id": "CD0100",
             "type": "UnityEngine.GUISkin",
             "method": "customStyles",
             "areas": ["Memory"],
@@ -638,7 +622,7 @@
             "solution": "Use GUISkin.GetStyle() or GUISkin.FindStyle() instead."
         },
         {
-            "id": "101103",
+            "id": "CD0103",
             "type": "UnityEngine.Collision",
             "method": "contacts",
             "areas": ["Memory"],
@@ -646,7 +630,7 @@
             "solution": "Use Collision.GetContacts() instead."
         },
         {
-            "id": "101104",
+            "id": "CD0104",
             "type": "UnityEngine.Collision2D",
             "method": "contacts",
             "areas": ["Memory"],
@@ -655,7 +639,7 @@
         },
 
         {
-            "id": "101110",
+            "id": "CD0110",
             "type": "UnityEngine.TerrainData",
             "method": "treeInstances",
             "areas": ["Memory"],
@@ -663,7 +647,7 @@
             "solution": "Use TerrainData.GetTreeInstance() instead."
         },
         {
-            "id": "101111",
+            "id": "CD0111",
             "type": "UnityEngine.TerrainData",
             "method": "alphamapTextures",
             "areas": ["Memory"],
@@ -671,7 +655,7 @@
             "solution": "Use TerrainData.GetAlphamapTexture() instead."
         },
         {
-            "id": "101112",
+            "id": "CD0112",
             "type": "UnityEngine.Font",
             "method": "characterInfo",
             "areas": ["Memory"],
@@ -679,7 +663,7 @@
             "solution": "Use Font.GetCharacterInfo() instead."
         },
         {
-            "id": "101115",
+            "id": "CD0115",
             "type": "UnityEngine.Animator",
             "method": "GetCurrentAnimationClipState",
             "areas": ["Memory"],
@@ -687,7 +671,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101116",
+            "id": "CD0116",
             "type": "UnityEngine.Animator",
             "method": "GetBehaviours",
             "areas": ["Memory"],
@@ -695,7 +679,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101117",
+            "id": "CD0117",
             "type": "UnityEngine.AssetBundle",
             "method": "LoadAssetWithSubAssets",
             "areas": ["Memory"],
@@ -703,7 +687,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101118",
+            "id": "CD0118",
             "type": "UnityEngine.AssetBundle",
             "method": "LoadAllAssets",
             "areas": ["Memory"],
@@ -711,7 +695,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101119",
+            "id": "CD0119",
             "type": "UnityEngine.AssetBundleManifest",
             "method": "GetAllAssetBundles",
             "areas": ["Memory"],
@@ -719,7 +703,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101120",
+            "id": "CD0120",
             "type": "UnityEngine.Resources",
             "method": "LoadAll",
             "areas": ["Memory"],
@@ -727,7 +711,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101121",
+            "id": "CD0121",
             "type": "UnityEngine.Texture2D",
             "method": "PackTextures",
             "areas": ["Memory"],
@@ -735,7 +719,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101122",
+            "id": "CD0122",
             "type": "UnityEngine.Cubemap",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -743,7 +727,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101123",
+            "id": "CD0123",
             "type": "UnityEngine.Texture3D",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -751,7 +735,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101124",
+            "id": "CD0124",
             "type": "UnityEngine.Texture3D",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -759,7 +743,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101125",
+            "id": "CD0125",
             "type": "UnityEngine.Texture2DArray",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -767,7 +751,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101126",
+            "id": "CD0126",
             "type": "UnityEngine.Texture2DArray",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -775,7 +759,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101127",
+            "id": "CD0127",
             "type": "UnityEngine.CubemapArray",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -783,7 +767,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101128",
+            "id": "CD0128",
             "type": "UnityEngine.CubemapArray",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -791,7 +775,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101129",
+            "id": "CD0129",
             "type": "UnityEngine.Object",
             "method": "FindObjectsOfType",
             "areas": ["Memory"],
@@ -799,7 +783,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101130",
+            "id": "CD0130",
             "type": "UnityEngine.Windows.Crypto",
             "method": "ComputeMD5Hash",
             "areas": ["Memory"],
@@ -807,7 +791,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101131",
+            "id": "CD0131",
             "type": "UnityEngine.Windows.File",
             "method": "ReadAllBytes",
             "areas": ["Memory"],
@@ -815,7 +799,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101132",
+            "id": "CD0132",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToJPG",
             "areas": ["Memory"],
@@ -823,7 +807,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101133",
+            "id": "CD0133",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToEXR",
             "areas": ["Memory"],
@@ -831,7 +815,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101134",
+            "id": "CD0134",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToTGA",
             "areas": ["Memory"],
@@ -839,7 +823,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101135",
+            "id": "CD0135",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToPNG",
             "areas": ["Memory"],
@@ -847,7 +831,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101136",
+            "id": "CD0136",
             "type": "UnityEngine.U2D.SpriteShapeUtility",
             "method": "Generate",
             "areas": ["Memory"],
@@ -856,7 +840,7 @@
             "minimumVersion": "2019.3"
         },
         {
-            "id": "101138",
+            "id": "CD0138",
             "type": "UnityEngine.AI.NavMeshTriangulation",
             "method": "layers",
             "areas": ["Memory"],
@@ -864,7 +848,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101139",
+            "id": "CD0139",
             "type": "UnityEngine.AnimationClip",
             "method": "events",
             "areas": ["Memory"],
@@ -872,7 +856,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101140",
+            "id": "CD0140",
             "type": "UnityEngine.AnimatorOverrideController",
             "method": "animationClips",
             "areas": ["Memory"],
@@ -880,7 +864,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101141",
+            "id": "CD0141",
             "type": "UnityEngine.HumanTrait",
             "method": "MuscleName",
             "areas": ["Memory"],
@@ -888,7 +872,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101142",
+            "id": "CD0142",
             "type": "UnityEngine.HumanTrait",
             "method": "BoneName",
             "areas": ["Memory"],
@@ -896,7 +880,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101143",
+            "id": "CD0143",
             "type": "UnityEngine.RuntimeAnimatorController",
             "method": "animationClips",
             "areas": ["Memory"],
@@ -904,7 +888,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101144",
+            "id": "CD0144",
             "type": "UnityEngine.AssetBundleRequest",
             "method": "allAssets",
             "areas": ["Memory"],
@@ -912,7 +896,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101145",
+            "id": "CD0145",
             "type": "UnityEngine.Microphone",
             "method": "devices",
             "areas": ["Memory"],
@@ -920,7 +904,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101146",
+            "id": "CD0146",
             "type": "UnityEngine.WebCamDevice",
             "method": "availableResolutions",
             "areas": ["Memory"],
@@ -928,7 +912,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101147",
+            "id": "CD0147",
             "type": "UnityEngine.WebCamTexture",
             "method": "devices",
             "areas": ["Memory"],
@@ -936,7 +920,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101148",
+            "id": "CD0148",
             "type": "UnityEngine.Cloth",
             "method": "vertices",
             "areas": ["Memory"],
@@ -944,7 +928,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101149",
+            "id": "CD0149",
             "type": "UnityEngine.Cloth",
             "method": "normals",
             "areas": ["Memory"],
@@ -952,7 +936,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101150",
+            "id": "CD0150",
             "type": "UnityEngine.Cloth",
             "method": "coefficients",
             "areas": ["Memory"],
@@ -960,7 +944,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101151",
+            "id": "CD0151",
             "type": "UnityEngine.Cloth",
             "method": "capsuleColliders",
             "areas": ["Memory"],
@@ -968,7 +952,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101152",
+            "id": "CD0152",
             "type": "UnityEngine.Cloth",
             "method": "sphereColliders",
             "areas": ["Memory"],
@@ -976,7 +960,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101153",
+            "id": "CD0153",
             "type": "UnityEngine.Camera",
             "method": "layerCullDistances",
             "areas": ["Memory"],
@@ -984,7 +968,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101154",
+            "id": "CD0154",
             "type": "UnityEngine.CrashReport",
             "method": "reports",
             "areas": ["Memory"],
@@ -992,7 +976,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101155",
+            "id": "CD0155",
             "type": "UnityEngine.Gradient",
             "method": "colorKeys",
             "areas": ["Memory"],
@@ -1000,7 +984,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101156",
+            "id": "CD0156",
             "type": "UnityEngine.Gradient",
             "method": "alphaKeys",
             "areas": ["Memory"],
@@ -1008,7 +992,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101157",
+            "id": "CD0157",
             "type": "UnityEngine.Screen",
             "method": "resolutions",
             "areas": ["Memory"],
@@ -1016,7 +1000,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101158",
+            "id": "CD0158",
             "type": "UnityEngine.LightmapSettings",
             "method": "lightmaps",
             "areas": ["Memory"],
@@ -1024,7 +1008,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101159",
+            "id": "CD0159",
             "type": "UnityEngine.LightProbes",
             "method": "positions",
             "areas": ["Memory"],
@@ -1032,7 +1016,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101160",
+            "id": "CD0160",
             "type": "UnityEngine.LightProbes",
             "method": "bakedProbes",
             "areas": ["Memory"],
@@ -1040,7 +1024,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101161",
+            "id": "CD0161",
             "type": "UnityEngine.LightProbes",
             "method": "coefficients",
             "areas": ["Memory"],
@@ -1048,7 +1032,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101162",
+            "id": "CD0162",
             "type": "UnityEngine.QualitySettings",
             "method": "names",
             "areas": ["Memory"],
@@ -1056,7 +1040,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101163",
+            "id": "CD0163",
             "type": "UnityEngine.Material",
             "method": "shaderKeywords",
             "areas": ["Memory"],
@@ -1064,7 +1048,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101164",
+            "id": "CD0164",
             "type": "UnityEngine.Light",
             "method": "layerShadowCullDistances",
             "areas": ["Memory"],
@@ -1072,7 +1056,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101165",
+            "id": "CD0165",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorRenderTargets",
             "areas": ["Memory"],
@@ -1080,7 +1064,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101166",
+            "id": "CD0166",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorLoadActions",
             "areas": ["Memory"],
@@ -1088,7 +1072,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101167",
+            "id": "CD0167",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorStoreActions",
             "areas": ["Memory"],
@@ -1096,7 +1080,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101168",
+            "id": "CD0168",
             "type": "UnityEngine.SkinnedMeshRenderer",
             "method": "bones",
             "areas": ["Memory"],
@@ -1104,7 +1088,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101169",
+            "id": "CD0169",
             "type": "UnityEngine.LightProbeGroup",
             "method": "probePositions",
             "areas": ["Memory"],
@@ -1112,7 +1096,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101170",
+            "id": "CD0170",
             "type": "UnityEngine.Network",
             "method": "connections",
             "areas": ["Memory"],
@@ -1121,7 +1105,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "101171",
+            "id": "CD0171",
             "type": "UnityEngine.HostData",
             "method": "ip",
             "areas": ["Memory"],
@@ -1130,7 +1114,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "101172",
+            "id": "CD0172",
             "type": "UnityEngine.SortingLayer",
             "method": "layers",
             "areas": ["Memory"],
@@ -1138,7 +1122,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101173",
+            "id": "CD0173",
             "type": "UnityEngine.TextAsset",
             "method": "bytes",
             "areas": ["Memory"],
@@ -1146,7 +1130,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101175",
+            "id": "CD0175",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "deviceToken",
             "areas": ["Memory"],
@@ -1156,7 +1140,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "101176",
+            "id": "CD0176",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "scheduledLocalNotifications",
             "areas": ["Memory"],
@@ -1166,7 +1150,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "101177",
+            "id": "CD0177",
             "type": "UnityEngine.Sprite",
             "method": "vertices",
             "areas": ["Memory"],
@@ -1174,7 +1158,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101178",
+            "id": "CD0178",
             "type": "UnityEngine.Sprite",
             "method": "triangles",
             "areas": ["Memory"],
@@ -1182,7 +1166,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101179",
+            "id": "CD0179",
             "type": "UnityEngine.Sprite",
             "method": "uv",
             "areas": ["Memory"],
@@ -1190,7 +1174,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101180",
+            "id": "CD0180",
             "type": "UnityEngine.SocialPlatforms.ILocalUser",
             "method": "friends",
             "areas": ["Memory"],
@@ -1198,7 +1182,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101181",
+            "id": "CD0181",
             "type": "UnityEngine.SocialPlatforms.ILeaderboard",
             "method": "scores",
             "areas": ["Memory"],
@@ -1206,7 +1190,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101182",
+            "id": "CD0182",
             "type": "UnityEngine.GUIStyleState",
             "method": "scaledBackgrounds",
             "areas": ["Memory"],
@@ -1214,7 +1198,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101183",
+            "id": "CD0183",
             "type": "UnityEngine.EdgeCollider2D",
             "method": "points",
             "areas": ["Memory"],
@@ -1222,7 +1206,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101184",
+            "id": "CD0184",
             "type": "UnityEngine.PolygonCollider2D",
             "method": "points",
             "areas": ["Memory"],
@@ -1230,7 +1214,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101185",
+            "id": "CD0185",
             "type": "UnityEngine.Terrain",
             "method": "activeTerrains",
             "areas": ["Memory"],
@@ -1238,7 +1222,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101186",
+            "id": "CD0186",
             "type": "UnityEngine.TerrainData",
             "method": "detailPrototypes",
             "areas": ["Memory"],
@@ -1246,7 +1230,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101187",
+            "id": "CD0187",
             "type": "UnityEngine.TerrainData",
             "method": "treePrototypes",
             "areas": ["Memory"],
@@ -1254,7 +1238,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101188",
+            "id": "CD0188",
             "type": "UnityEngine.TerrainData",
             "method": "splatPrototypes",
             "areas": ["Memory"],
@@ -1262,7 +1246,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101189",
+            "id": "CD0189",
             "type": "UnityEngine.TerrainData",
             "method": "terrainLayers",
             "areas": ["Memory"],
@@ -1270,7 +1254,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101190",
+            "id": "CD0190",
             "type": "UnityEngine.Tilemaps.TileAnimationData",
             "method": "animatedSprites",
             "areas": ["Memory"],
@@ -1278,7 +1262,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101191",
+            "id": "CD0191",
             "type": "UnityEngine.UIElements.UxmlAttributeDescription",
             "method": "obsoleteNames",
             "areas": ["Memory"],
@@ -1287,7 +1271,7 @@
             "minimumVersion": "2019.1"
         },
         {
-            "id": "101200",
+            "id": "CD0200",
             "type": "UnityEngine.Networking.IMultipartFormSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1295,7 +1279,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101201",
+            "id": "CD0201",
             "type": "UnityEngine.Networking.MultipartFormDataSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1303,7 +1287,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101202",
+            "id": "CD0202",
             "type": "UnityEngine.Networking.MultipartFormFileSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1311,7 +1295,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101203",
+            "id": "CD0203",
             "type": "UnityEngine.WWWForm",
             "method": "data",
             "areas": ["Memory"],
@@ -1319,7 +1303,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101204",
+            "id": "CD0204",
             "type": "UnityEngine.Networking.DownloadHandler",
             "method": "data",
             "areas": ["Memory"],
@@ -1327,7 +1311,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101208",
+            "id": "CD0208",
             "type": "UnityEngine.Networking.UploadHandler",
             "method": "data",
             "areas": ["Memory"],
@@ -1335,7 +1319,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101215",
+            "id": "CD0215",
             "type": "UnityEngine.Networking.NetworkMigrationManager",
             "method": "peers",
             "areas": ["Memory"],
@@ -1344,7 +1328,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "101216",
+            "id": "CD0216",
             "type": "UnityEngine.Networking.NetworkServerSimple",
             "method": "messageBuffer",
             "areas": ["Memory"],
@@ -1353,7 +1337,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "101217",
+            "id": "CD0217",
             "type": "UnityEngine.WWW",
             "method": "bytes",
             "areas": ["Memory"],
@@ -1361,7 +1345,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101219",
+            "id": "CD0219",
             "type": "UnityEngine.XR.XRSettings",
             "method": "supportedDevices",
             "areas": ["Memory"],
@@ -1369,7 +1353,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101220",
+            "id": "CD0220",
             "type": "UnityEngine.TestTools.Constraints.AllocatingGCMemoryConstraint",
             "method": "Arguments",
             "areas": ["Memory"],
@@ -1377,7 +1361,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101221",
+            "id": "CD0221",
             "type": "UnityEngine.TestTools.UnityPlatformAttribute",
             "method": "include",
             "areas": ["Memory"],
@@ -1385,7 +1369,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101222",
+            "id": "CD0222",
             "type": "UnityEngine.TestTools.UnityPlatformAttribute",
             "method": "exclude",
             "areas": ["Memory"],
@@ -1393,7 +1377,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "101223",
+            "id": "CD0223",
             "type": "UnityEngine.GameObject",
             "method": "tag",
             "areas": ["Memory"],
@@ -1401,7 +1385,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer using GameObject.CompareTag() instead, as this does not result in managed allocations."
         },
         {
-            "id": "101224",
+            "id": "CD0224",
             "type": "UnityEngine.Object",
             "method": "Instantiate",
             "areas": ["CPU"],
@@ -1409,7 +1393,7 @@
             "solution": "Try to avoid calling Object.Instantiate frequently-updated code."
         },
         {
-            "id": "101225",
+            "id": "CD0225",
             "type": "UnityEngine.GameObject",
             "method": "AddComponent",
             "areas": ["CPU"],
@@ -1417,16 +1401,8 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer instantiating GameObjects from Prefabs will all the necessary components instead."
         },
         {
-            "id": "101226",
-            "type": "System.String",
-            "method": "Concat",
-            "areas": ["Memory"],
-            "problem": "String concatenation operations allocates managed memory",
-            "solution": "Try to avoid concatenating strings in frequently-updated code. Prefer using a StringBuilder instead, as this minimizes managed allocations."
-        },
-        {
-          "id": "101227",
-            "type": "UnityEngine.Shader",
+          "id": "CD0227",
+          "type": "UnityEngine.Shader",
           "method": "WarmupAllShaders",
           "areas": ["CPU"],
           "critical": "true",
@@ -1434,7 +1410,7 @@
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader used at runtime."
         },
         {
-          "id": "101228",
+          "id": "CD0228",
           "type": "UnityEngine.ShaderVariantCollection",
           "method": "WarmUp",
           "areas": ["CPU"],
@@ -1443,7 +1419,7 @@
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader variant used at runtime."
         },
         {
-          "id": "101229",
+          "id": "CD0229",
           "type": "UnityEngine.Component",
           "method": "tag",
           "areas": ["Memory"],
@@ -1451,15 +1427,7 @@
           "solution": "Try to avoid getting this property in frequently-updated code. Prefer using CompareTag() instead, as this does not result in managed allocations."
         },
         {
-          "id": "101230",
-          "type": "System.DateTime",
-          "method": "Now",
-          "areas": ["CPU"],
-          "problem": "System.DateTime.Now is expensive because it needs to figure out the current timezone and daylight saving time information.",
-          "solution": "Try to avoid using this method in frequently-updated code. Prefer UnityEngine.Time.time or, if precise time is needed, use DateTime.UtcNow."
-        },
-        {
-          "id": "101231",
+          "id": "CD0231",
           "type": "UnityEngine.Object",
           "method": "name",
           "areas": ["Memory"],
@@ -1467,7 +1435,39 @@
           "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-          "id": 101232,
+          "id": "CD1000",
+          "type": "System.Linq",
+          "method": "*",
+          "areas": ["Memory"],
+          "problem": "Linq allocates large amounts of managed memory.",
+          "solution": "We strongly advise against using Linq in any frequently-updated code. Ban its usage from the project entirely, or confine it to initialization code and use it sparingly."
+        },
+        {
+          "id": "CD1001",
+          "type": "System.Reflection",
+          "method": "*",
+          "areas": ["CPU"],
+          "problem": "Reflection is slow, and not generally considered performant enough for runtime code.",
+          "solution": "Remove code which relies on reflection, or minimise its usage, particularly outside of initialization."
+        },
+        {
+          "id": "CD1002",
+          "type": "System.String",
+          "method": "Concat",
+          "areas": ["Memory"],
+          "problem": "String concatenation operations allocates managed memory",
+          "solution": "Try to avoid concatenating strings in frequently-updated code. Prefer using a StringBuilder instead, as this minimizes managed allocations."
+        },
+        {
+          "id": "CD1003",
+          "type": "System.DateTime",
+          "method": "Now",
+          "areas": ["CPU"],
+          "problem": "System.DateTime.Now is expensive because it needs to figure out the current timezone and daylight saving time information.",
+          "solution": "Try to avoid using this method in frequently-updated code. Prefer UnityEngine.Time.time or, if precise time is needed, use DateTime.UtcNow."
+        },
+        {
+          "id": "CD0232",
           "type": "System.AppDomain",
           "method": "GetAssemblies",
           "areas": ["CPU"],

--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -1,7 +1,7 @@
 {
     "Items": [
         {
-            "id": 101000,
+            "id": "101000",
             "type": "UnityEngine.Camera",
             "method": "main",
             "areas": ["CPU"],
@@ -10,7 +10,7 @@
             "maximumVersion": "2019.4.8"
         },
         {
-            "id": 101001,
+            "id": "101001",
             "type": "UnityEngine.WebCamTexture",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -18,7 +18,7 @@
             "solution": "Use WebCamTexture.GetPixels32() instead."
         },
         {
-            "id": 101002,
+            "id": "101002",
             "type": "UnityEngine.WebCamTexture",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -26,7 +26,7 @@
             "solution": "Ensure that you pass an array of Color32[] to this API method for it to fill out, to avoid creating a new array every time the method is called."
         },
         {
-            "id": 101003,
+            "id": "101003",
             "type": "UnityEngine.GeometryUtility",
             "method": "CalculateFrustumPlanes",
             "areas": ["Memory"],
@@ -34,7 +34,7 @@
             "solution": "Ensure that you use the CalculateFrustumPlanes(Matrix4x4 worldToProjectionMatrix, Plane[] planes) version of this API method, in order to be able to pass a pre-allocated Array of Planes."
         },
         {
-            "id": 101004,
+            "id": "101004",
             "type": "UnityEngine.Resources",
             "method": "FindObjectsOfTypeAll",
             "areas": ["Memory"],
@@ -42,7 +42,7 @@
             "solution": "Use Resources.FindObjectsOfTypeNonAlloc() instead."
         },
         {
-            "id": 101005,
+            "id": "101005",
             "type": "UnityEngine.Texture2D",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -50,7 +50,7 @@
             "solution": "Use Texture2D.GetRawTextureData() instead. This method returns a NativeArray of pixel data, and so does not allocate managed memory."
         },
         {
-            "id": 101006,
+            "id": "101006",
             "type": "UnityEngine.Texture2D",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -58,7 +58,7 @@
             "solution": "Use Texture2D.GetRawTextureData() instead. This method returns a NativeArray of pixel data, and so does not allocate managed memory."
         },
         {
-            "id": 101007,
+            "id": "101007",
             "type": "UnityEngine.Rigidbody",
             "method": "SweepTestAll",
             "areas": ["Memory"],
@@ -66,7 +66,7 @@
             "solution": "Use Rigidbody.SweepTestNonAlloc() instead."
         },
         {
-            "id": 101008,
+            "id": "101008",
             "type": "UnityEngine.Physics",
             "method": "RaycastAll",
             "areas": ["Memory"],
@@ -74,7 +74,7 @@
             "solution": "Use Physics.RaycastNonAlloc() instead."
         },
         {
-            "id": 101009,
+            "id": "101009",
             "type": "UnityEngine.Physics",
             "method": "CapsuleCastAll",
             "areas": ["Memory"],
@@ -82,7 +82,7 @@
             "solution": "Use Physics.CapsuleCastNonAlloc() instead."
         },
         {
-            "id": 101010,
+            "id": "101010",
             "type": "UnityEngine.Physics",
             "method": "SphereCastAll",
             "areas": ["Memory"],
@@ -90,7 +90,7 @@
             "solution": "Use Physics.SphereCastNonAlloc() instead."
         },
         {
-            "id": 101011,
+            "id": "101011",
             "type": "UnityEngine.Physics",
             "method": "BoxCastAll",
             "areas": ["Memory"],
@@ -98,7 +98,7 @@
             "solution": "Use Physics.BoxCastNonAlloc() instead."
         },
         {
-            "id": 101012,
+            "id": "101012",
             "type": "UnityEngine.Physics",
             "method": "OverlapCapsule",
             "areas": ["Memory"],
@@ -106,7 +106,7 @@
             "solution": "Use Physics.OverlapCapsuleNonAlloc() instead."
         },
         {
-            "id": 101013,
+            "id": "101013",
             "type": "UnityEngine.Physics",
             "method": "OverlapSphere",
             "areas": ["Memory"],
@@ -114,7 +114,7 @@
             "solution": "Use Physics.OverlapSphereNonAlloc() instead."
         },
         {
-            "id": 101014,
+            "id": "101014",
             "type": "UnityEngine.Physics",
             "method": "OverlapBox",
             "areas": ["Memory"],
@@ -122,7 +122,7 @@
             "solution": "Use Physics.OverlapBoxNonAlloc() instead."
         },
         {
-            "id": 101015,
+            "id": "101015",
             "type": "UnityEngine.Physics2D",
             "method": "LinecastAll",
             "areas": ["Memory"],
@@ -130,7 +130,7 @@
             "solution": "Use Physics2D.LinecastNonAlloc() instead."
         },
         {
-            "id": 101016,
+            "id": "101016",
             "type": "UnityEngine.Physics2D",
             "method": "RaycastAll",
             "areas": ["Memory"],
@@ -138,7 +138,7 @@
             "solution": "Use Physics2D.RaycastNonAlloc() instead."
         },
         {
-            "id": 101017,
+            "id": "101017",
             "type": "UnityEngine.Physics2D",
             "method": "CircleCastAll",
             "areas": ["Memory"],
@@ -146,7 +146,7 @@
             "solution": "Use Physics2D.CircleCastNonAlloc() instead."
         },
         {
-            "id": 101018,
+            "id": "101018",
             "type": "UnityEngine.Physics2D",
             "method": "BoxCastAll",
             "areas": ["Memory"],
@@ -154,7 +154,7 @@
             "solution": "Use Physics2D.BoxCastNonAlloc() instead."
         },
         {
-            "id": 101019,
+            "id": "101019",
             "type": "UnityEngine.Physics2D",
             "method": "CapsuleCastAll",
             "areas": ["Memory"],
@@ -162,7 +162,7 @@
             "solution": "Use Physics2D.CapsuleCastNonAlloc() instead."
         },
         {
-            "id": 101020,
+            "id": "101020",
             "type": "UnityEngine.Physics2D",
             "method": "GetRayIntersectionAll",
             "areas": ["Memory"],
@@ -170,7 +170,7 @@
             "solution": "Use Physics2D.GetRayIntersectionNonAlloc() instead."
         },
         {
-            "id": 101021,
+            "id": "101021",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapPointAll",
             "areas": ["Memory"],
@@ -178,7 +178,7 @@
             "solution": "Use Physics2D.OverlapPointNonAlloc() instead."
         },
         {
-            "id": 101022,
+            "id": "101022",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapCircleAll",
             "areas": ["Memory"],
@@ -186,7 +186,7 @@
             "solution": "Use Physics2D.OverlapCircleNonAlloc() instead."
         },
         {
-            "id": 101023,
+            "id": "101023",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapBoxAll",
             "areas": ["Memory"],
@@ -194,7 +194,7 @@
             "solution": "Use Physics2D.OverlapBoxNonAlloc() instead."
         },
         {
-            "id": 101024,
+            "id": "101024",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapAreaAll",
             "areas": ["Memory"],
@@ -202,7 +202,7 @@
             "solution": "Use Physics2D.OverlapAreaNonAlloc() instead."
         },
         {
-            "id": 101025,
+            "id": "101025",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapCapsuleAll",
             "areas": ["Memory"],
@@ -210,7 +210,7 @@
             "solution": "Use Physics2D.OverlapCapsuleNonAlloc() instead."
         },
         {
-            "id": 101026,
+            "id": "101026",
             "type": "UnityEngine.Component",
             "method": "GetComponentsInChildren",
             "areas": ["Memory"],
@@ -218,7 +218,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInChildren() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": 101027,
+            "id": "101027",
             "type": "UnityEngine.Component",
             "method": "GetComponentsInParent",
             "areas": ["Memory"],
@@ -226,7 +226,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInParent() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": 101028,
+            "id": "101028",
             "type": "UnityEngine.GameObject",
             "method": "GetComponentsInChildren",
             "areas": ["Memory"],
@@ -234,7 +234,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInChildren() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": 101029,
+            "id": "101029",
             "type": "UnityEngine.GameObject",
             "method": "GetComponentsInParent",
             "areas": ["Memory"],
@@ -242,7 +242,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInParent() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": 101030,
+            "id": "101030",
             "type": "UnityEngine.Collider",
             "method": "OnTriggerStay",
             "areas": ["CPU"],
@@ -250,7 +250,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101031,
+            "id": "101031",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnTriggerStay",
             "areas": ["CPU"],
@@ -258,7 +258,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101032,
+            "id": "101032",
             "type": "UnityEngine.Collider2D",
             "method": "OnTriggerStay2D",
             "areas": ["CPU"],
@@ -266,7 +266,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay2D() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101033,
+            "id": "101033",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnTriggerStay2D",
             "areas": ["CPU"],
@@ -274,7 +274,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay2D() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101034,
+            "id": "101034",
             "type": "UnityEngine.Collider",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -282,7 +282,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101035,
+            "id": "101035",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -290,7 +290,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101036,
+            "id": "101036",
             "type": "UnityEngine.Rigidbody",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -298,7 +298,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": 101037,
+            "id": "101037",
             "type": "UnityEngine.ImageConversion",
             "method": "LoadImage",
             "areas": ["Memory"],
@@ -306,7 +306,7 @@
             "solution": "If a CPU-accessible copy of the texture is not required, ensure that the markNonReadable flag passed into the method is set to true."
         },
         {
-            "id": 101039,
+            "id": "101039",
             "type": "UnityEngine.Renderer",
             "method": "material",
             "areas": ["GPU"],
@@ -314,7 +314,7 @@
             "solution": "If possible, use Renderer.sharedMaterial instead."
         },
         {
-            "id": 101049,
+            "id": "101049",
             "type": "System.Linq",
             "method": "*",
             "areas": ["Memory"],
@@ -322,7 +322,7 @@
             "solution": "We strongly advise against using Linq in any frequently-updated code. Ban its usage from the project entirely, or confine it to initialization code and use it sparingly."
         },
         {
-            "id": 101050,
+            "id": "101050",
             "type": "System.Reflection",
             "method": "*",
             "areas": ["CPU"],
@@ -330,7 +330,7 @@
             "solution": "Remove code which relies on reflection, or minimise its usage, particularly outside of initialization."
         },
         {
-            "id": 101051,
+            "id": "101051",
             "type": "UnityEngine.ComputeBuffer",
             "method": "GetData",
             "areas": ["CPU"],
@@ -338,7 +338,7 @@
             "solution": "Avoid reading back from ComputeBuffers if it is at all possible. If it's unavoidable, profile your project carefully and regularly to monitor the performance impact."
         },
         {
-            "id": 101052,
+            "id": "101052",
             "type": "UnityEngine.Texture2D",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -346,7 +346,7 @@
             "solution": "Use Texture2D.SetPixels32() or GetRawTextureData()/Apply() instead."
         },
         {
-            "id": 101053,
+            "id": "101053",
             "type": "UnityEngine.Texture3D",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -354,7 +354,7 @@
             "solution": "Use Texture3D.SetPixels32() instead."
         },
         {
-            "id": 101054,
+            "id": "101054",
             "type": "UnityEngine.Texture2DArray",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -362,7 +362,7 @@
             "solution": "Use Texture2DArray.SetPixels32() instead."
         },
         {
-            "id": 101055,
+            "id": "101055",
             "type": "UnityEngine.CubemapArray",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -370,7 +370,7 @@
             "solution": "Use CubemapArray.SetPixels32() instead."
         },
         {
-            "id": 101056,
+            "id": "101056",
             "type": "UnityEngine.GameObject",
             "method": "SendMessage",
             "areas": ["CPU"],
@@ -378,7 +378,7 @@
             "solution": "Implement a custom system to replace SendMessage - get the components you want to send messages and call methods directly on them."
         },
         {
-            "id": 101057,
+            "id": "101057",
             "type": "UnityEngine.Component",
             "method": "SendMessage",
             "areas": ["CPU"],
@@ -386,7 +386,7 @@
             "solution": "Implement a custom system to replace SendMessage - get the components you want to send messages and call methods directly on them."
         },
         {
-            "id": 101058,
+            "id": "101058",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnGUI",
             "areas": ["CPU"],
@@ -394,7 +394,7 @@
             "solution": "Remove all OnGUI() methods from the project code."
         },
         {
-            "id": 101059,
+            "id": "101059",
             "type": "UnityEngine.AI.NavMeshPath",
             "method": "corners",
             "areas": ["Memory"],
@@ -402,7 +402,7 @@
             "solution": "Use AI.NavMeshPath.GetCornersNonAlloc() instead"
         },
         {
-            "id": 101060,
+            "id": "101060",
             "type": "UnityEngine.Animator",
             "method": "parameters",
             "areas": ["Memory"],
@@ -410,7 +410,7 @@
             "solution": "Use Animator.GetParameter() instead."
         },
         {
-            "id": 101061,
+            "id": "101061",
             "type": "UnityEngine.Animations.ParentConstraint",
             "method": "translationOffsets",
             "areas": ["Memory"],
@@ -418,7 +418,7 @@
             "solution": "Use Animations.ParentConstraint.GetTranslationOffset() instead."
         },
         {
-            "id": 101062,
+            "id": "101062",
             "type": "UnityEngine.Animations.ParentConstraint",
             "method": "rotationOffsets",
             "areas": ["Memory"],
@@ -426,7 +426,7 @@
             "solution": "Use Animations.ParentConstraint.GetRotationOffset() instead."
         },
         {
-            "id": 101063,
+            "id": "101063",
             "type": "UnityEngine.AnimationCurve",
             "method": "keys",
             "areas": ["Memory"],
@@ -434,7 +434,7 @@
             "solution": "Use AnimationCurve.AddKey()/MoveKey()/RemoveKey() instead."
         },
         {
-            "id": 101066,
+            "id": "101066",
             "type": "UnityEngine.Camera",
             "method": "allCameras",
             "areas": ["Memory"],
@@ -442,7 +442,7 @@
             "solution": "Use Camera.GetAllCameras() instead."
         },
         {
-            "id": 101067,
+            "id": "101067",
             "type": "UnityEngine.Mesh",
             "method": "boneWeights",
             "areas": ["Memory"],
@@ -450,7 +450,7 @@
             "solution": "Use Mesh.GetAllBoneWeights() instead. This method returns a NativeArray of BoneWeight1, and so does not allocate managed memory."
         },
         {
-            "id": 101068,
+            "id": "101068",
             "type": "UnityEngine.Mesh",
             "method": "bindposes",
             "areas": ["Memory"],
@@ -458,7 +458,7 @@
             "solution": "Use Mesh.GetBindposes() instead."
         },
         {
-            "id": 101069,
+            "id": "101069",
             "type": "UnityEngine.Mesh",
             "method": "vertices",
             "areas": ["Memory"],
@@ -466,7 +466,7 @@
             "solution": "Use Mesh.GetVertices() instead."
         },
         {
-            "id": 101070,
+            "id": "101070",
             "type": "UnityEngine.Mesh",
             "method": "normals",
             "areas": ["Memory"],
@@ -474,7 +474,7 @@
             "solution": "Use Mesh.GetNormals() instead."
         },
         {
-            "id": 101071,
+            "id": "101071",
             "type": "UnityEngine.Mesh",
             "method": "tangents",
             "areas": ["Memory"],
@@ -482,7 +482,7 @@
             "solution": "Use Mesh.GetTangents() instead."
         },
         {
-            "id": 101072,
+            "id": "101072",
             "type": "UnityEngine.Mesh",
             "method": "uv",
             "areas": ["Memory"],
@@ -490,7 +490,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101073,
+            "id": "101073",
             "type": "UnityEngine.Mesh",
             "method": "uv1",
             "areas": ["Memory"],
@@ -498,7 +498,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101074,
+            "id": "101074",
             "type": "UnityEngine.Mesh",
             "method": "uv2",
             "areas": ["Memory"],
@@ -506,7 +506,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101075,
+            "id": "101075",
             "type": "UnityEngine.Mesh",
             "method": "uv3",
             "areas": ["Memory"],
@@ -514,7 +514,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101076,
+            "id": "101076",
             "type": "UnityEngine.Mesh",
             "method": "uv4",
             "areas": ["Memory"],
@@ -522,7 +522,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101077,
+            "id": "101077",
             "type": "UnityEngine.Mesh",
             "method": "uv5",
             "areas": ["Memory"],
@@ -530,7 +530,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101078,
+            "id": "101078",
             "type": "UnityEngine.Mesh",
             "method": "uv6",
             "areas": ["Memory"],
@@ -538,7 +538,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101079,
+            "id": "101079",
             "type": "UnityEngine.Mesh",
             "method": "uv7",
             "areas": ["Memory"],
@@ -546,7 +546,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101080,
+            "id": "101080",
             "type": "UnityEngine.Mesh",
             "method": "uv8",
             "areas": ["Memory"],
@@ -554,7 +554,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": 101081,
+            "id": "101081",
             "type": "UnityEngine.Mesh",
             "method": "colors",
             "areas": ["Memory"],
@@ -562,7 +562,7 @@
             "solution": "Use Mesh.GetColors() instead."
         },
         {
-            "id": 101082,
+            "id": "101082",
             "type": "UnityEngine.Mesh",
             "method": "colors32",
             "areas": ["Memory"],
@@ -570,7 +570,7 @@
             "solution": "Use Mesh.GetColors() instead."
         },
         {
-            "id": 101083,
+            "id": "101083",
             "type": "UnityEngine.Mesh",
             "method": "triangles",
             "areas": ["Memory"],
@@ -578,7 +578,7 @@
             "solution": "Use Mesh.GetTriangles() instead."
         },
         {
-            "id": 101084,
+            "id": "101084",
             "type": "UnityEngine.Renderer",
             "method": "materials",
             "areas": ["Memory"],
@@ -586,7 +586,7 @@
             "solution": "Use Renderer.GetMaterials() instead."
         },
         {
-            "id": 101085,
+            "id": "101085",
             "type": "UnityEngine.Renderer",
             "method": "sharedMaterials",
             "areas": ["Memory"],
@@ -594,7 +594,7 @@
             "solution": "Use Renderer.GetSharedMaterials() instead."
         },
         {
-            "id": 101094,
+            "id": "101094",
             "type": "UnityEngine.Input",
             "method": "touches",
             "areas": ["Memory"],
@@ -602,7 +602,7 @@
             "solution": "Use Input.GetTouch() instead."
         },
         {
-            "id": 101095,
+            "id": "101095",
             "type": "UnityEngine.Input",
             "method": "accelerationEvents",
             "areas": ["Memory"],
@@ -610,7 +610,7 @@
             "solution": "Use Input.GetAccelerationEvent() instead."
         },
         {
-            "id": 101096,
+            "id": "101096",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "localNotifications",
             "areas": ["Memory"],
@@ -620,7 +620,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": 101097,
+            "id": "101097",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "remoteNotifications",
             "areas": ["Memory"],
@@ -630,7 +630,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": 101100,
+            "id": "101100",
             "type": "UnityEngine.GUISkin",
             "method": "customStyles",
             "areas": ["Memory"],
@@ -638,7 +638,7 @@
             "solution": "Use GUISkin.GetStyle() or GUISkin.FindStyle() instead."
         },
         {
-            "id": 101103,
+            "id": "101103",
             "type": "UnityEngine.Collision",
             "method": "contacts",
             "areas": ["Memory"],
@@ -646,7 +646,7 @@
             "solution": "Use Collision.GetContacts() instead."
         },
         {
-            "id": 101104,
+            "id": "101104",
             "type": "UnityEngine.Collision2D",
             "method": "contacts",
             "areas": ["Memory"],
@@ -655,7 +655,7 @@
         },
 
         {
-            "id": 101110,
+            "id": "101110",
             "type": "UnityEngine.TerrainData",
             "method": "treeInstances",
             "areas": ["Memory"],
@@ -663,7 +663,7 @@
             "solution": "Use TerrainData.GetTreeInstance() instead."
         },
         {
-            "id": 101111,
+            "id": "101111",
             "type": "UnityEngine.TerrainData",
             "method": "alphamapTextures",
             "areas": ["Memory"],
@@ -671,7 +671,7 @@
             "solution": "Use TerrainData.GetAlphamapTexture() instead."
         },
         {
-            "id": 101112,
+            "id": "101112",
             "type": "UnityEngine.Font",
             "method": "characterInfo",
             "areas": ["Memory"],
@@ -679,7 +679,7 @@
             "solution": "Use Font.GetCharacterInfo() instead."
         },
         {
-            "id": 101115,
+            "id": "101115",
             "type": "UnityEngine.Animator",
             "method": "GetCurrentAnimationClipState",
             "areas": ["Memory"],
@@ -687,7 +687,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101116,
+            "id": "101116",
             "type": "UnityEngine.Animator",
             "method": "GetBehaviours",
             "areas": ["Memory"],
@@ -695,7 +695,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101117,
+            "id": "101117",
             "type": "UnityEngine.AssetBundle",
             "method": "LoadAssetWithSubAssets",
             "areas": ["Memory"],
@@ -703,7 +703,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101118,
+            "id": "101118",
             "type": "UnityEngine.AssetBundle",
             "method": "LoadAllAssets",
             "areas": ["Memory"],
@@ -711,7 +711,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101119,
+            "id": "101119",
             "type": "UnityEngine.AssetBundleManifest",
             "method": "GetAllAssetBundles",
             "areas": ["Memory"],
@@ -719,7 +719,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101120,
+            "id": "101120",
             "type": "UnityEngine.Resources",
             "method": "LoadAll",
             "areas": ["Memory"],
@@ -727,7 +727,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101121,
+            "id": "101121",
             "type": "UnityEngine.Texture2D",
             "method": "PackTextures",
             "areas": ["Memory"],
@@ -735,7 +735,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101122,
+            "id": "101122",
             "type": "UnityEngine.Cubemap",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -743,7 +743,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101123,
+            "id": "101123",
             "type": "UnityEngine.Texture3D",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -751,7 +751,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101124,
+            "id": "101124",
             "type": "UnityEngine.Texture3D",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -759,7 +759,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101125,
+            "id": "101125",
             "type": "UnityEngine.Texture2DArray",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -767,7 +767,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101126,
+            "id": "101126",
             "type": "UnityEngine.Texture2DArray",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -775,7 +775,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101127,
+            "id": "101127",
             "type": "UnityEngine.CubemapArray",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -783,7 +783,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101128,
+            "id": "101128",
             "type": "UnityEngine.CubemapArray",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -791,7 +791,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101129,
+            "id": "101129",
             "type": "UnityEngine.Object",
             "method": "FindObjectsOfType",
             "areas": ["Memory"],
@@ -799,7 +799,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101130,
+            "id": "101130",
             "type": "UnityEngine.Windows.Crypto",
             "method": "ComputeMD5Hash",
             "areas": ["Memory"],
@@ -807,7 +807,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101131,
+            "id": "101131",
             "type": "UnityEngine.Windows.File",
             "method": "ReadAllBytes",
             "areas": ["Memory"],
@@ -815,7 +815,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101132,
+            "id": "101132",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToJPG",
             "areas": ["Memory"],
@@ -823,7 +823,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101133,
+            "id": "101133",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToEXR",
             "areas": ["Memory"],
@@ -831,7 +831,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101134,
+            "id": "101134",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToTGA",
             "areas": ["Memory"],
@@ -839,7 +839,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101135,
+            "id": "101135",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToPNG",
             "areas": ["Memory"],
@@ -847,7 +847,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101136,
+            "id": "101136",
             "type": "UnityEngine.U2D.SpriteShapeUtility",
             "method": "Generate",
             "areas": ["Memory"],
@@ -856,7 +856,7 @@
             "minimumVersion": "2019.3"
         },
         {
-            "id": 101138,
+            "id": "101138",
             "type": "UnityEngine.AI.NavMeshTriangulation",
             "method": "layers",
             "areas": ["Memory"],
@@ -864,7 +864,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101139,
+            "id": "101139",
             "type": "UnityEngine.AnimationClip",
             "method": "events",
             "areas": ["Memory"],
@@ -872,7 +872,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101140,
+            "id": "101140",
             "type": "UnityEngine.AnimatorOverrideController",
             "method": "animationClips",
             "areas": ["Memory"],
@@ -880,7 +880,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101141,
+            "id": "101141",
             "type": "UnityEngine.HumanTrait",
             "method": "MuscleName",
             "areas": ["Memory"],
@@ -888,7 +888,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101142,
+            "id": "101142",
             "type": "UnityEngine.HumanTrait",
             "method": "BoneName",
             "areas": ["Memory"],
@@ -896,7 +896,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101143,
+            "id": "101143",
             "type": "UnityEngine.RuntimeAnimatorController",
             "method": "animationClips",
             "areas": ["Memory"],
@@ -904,7 +904,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101144,
+            "id": "101144",
             "type": "UnityEngine.AssetBundleRequest",
             "method": "allAssets",
             "areas": ["Memory"],
@@ -912,7 +912,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101145,
+            "id": "101145",
             "type": "UnityEngine.Microphone",
             "method": "devices",
             "areas": ["Memory"],
@@ -920,7 +920,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101146,
+            "id": "101146",
             "type": "UnityEngine.WebCamDevice",
             "method": "availableResolutions",
             "areas": ["Memory"],
@@ -928,7 +928,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101147,
+            "id": "101147",
             "type": "UnityEngine.WebCamTexture",
             "method": "devices",
             "areas": ["Memory"],
@@ -936,7 +936,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101148,
+            "id": "101148",
             "type": "UnityEngine.Cloth",
             "method": "vertices",
             "areas": ["Memory"],
@@ -944,7 +944,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101149,
+            "id": "101149",
             "type": "UnityEngine.Cloth",
             "method": "normals",
             "areas": ["Memory"],
@@ -952,7 +952,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101150,
+            "id": "101150",
             "type": "UnityEngine.Cloth",
             "method": "coefficients",
             "areas": ["Memory"],
@@ -960,7 +960,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101151,
+            "id": "101151",
             "type": "UnityEngine.Cloth",
             "method": "capsuleColliders",
             "areas": ["Memory"],
@@ -968,7 +968,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101152,
+            "id": "101152",
             "type": "UnityEngine.Cloth",
             "method": "sphereColliders",
             "areas": ["Memory"],
@@ -976,7 +976,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101153,
+            "id": "101153",
             "type": "UnityEngine.Camera",
             "method": "layerCullDistances",
             "areas": ["Memory"],
@@ -984,7 +984,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101154,
+            "id": "101154",
             "type": "UnityEngine.CrashReport",
             "method": "reports",
             "areas": ["Memory"],
@@ -992,7 +992,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101155,
+            "id": "101155",
             "type": "UnityEngine.Gradient",
             "method": "colorKeys",
             "areas": ["Memory"],
@@ -1000,7 +1000,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101156,
+            "id": "101156",
             "type": "UnityEngine.Gradient",
             "method": "alphaKeys",
             "areas": ["Memory"],
@@ -1008,7 +1008,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101157,
+            "id": "101157",
             "type": "UnityEngine.Screen",
             "method": "resolutions",
             "areas": ["Memory"],
@@ -1016,7 +1016,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101158,
+            "id": "101158",
             "type": "UnityEngine.LightmapSettings",
             "method": "lightmaps",
             "areas": ["Memory"],
@@ -1024,7 +1024,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101159,
+            "id": "101159",
             "type": "UnityEngine.LightProbes",
             "method": "positions",
             "areas": ["Memory"],
@@ -1032,7 +1032,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101160,
+            "id": "101160",
             "type": "UnityEngine.LightProbes",
             "method": "bakedProbes",
             "areas": ["Memory"],
@@ -1040,7 +1040,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101161,
+            "id": "101161",
             "type": "UnityEngine.LightProbes",
             "method": "coefficients",
             "areas": ["Memory"],
@@ -1048,7 +1048,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101162,
+            "id": "101162",
             "type": "UnityEngine.QualitySettings",
             "method": "names",
             "areas": ["Memory"],
@@ -1056,7 +1056,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101163,
+            "id": "101163",
             "type": "UnityEngine.Material",
             "method": "shaderKeywords",
             "areas": ["Memory"],
@@ -1064,7 +1064,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101164,
+            "id": "101164",
             "type": "UnityEngine.Light",
             "method": "layerShadowCullDistances",
             "areas": ["Memory"],
@@ -1072,7 +1072,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101165,
+            "id": "101165",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorRenderTargets",
             "areas": ["Memory"],
@@ -1080,7 +1080,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101166,
+            "id": "101166",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorLoadActions",
             "areas": ["Memory"],
@@ -1088,7 +1088,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101167,
+            "id": "101167",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorStoreActions",
             "areas": ["Memory"],
@@ -1096,7 +1096,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101168,
+            "id": "101168",
             "type": "UnityEngine.SkinnedMeshRenderer",
             "method": "bones",
             "areas": ["Memory"],
@@ -1104,7 +1104,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101169,
+            "id": "101169",
             "type": "UnityEngine.LightProbeGroup",
             "method": "probePositions",
             "areas": ["Memory"],
@@ -1112,7 +1112,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101170,
+            "id": "101170",
             "type": "UnityEngine.Network",
             "method": "connections",
             "areas": ["Memory"],
@@ -1121,7 +1121,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": 101171,
+            "id": "101171",
             "type": "UnityEngine.HostData",
             "method": "ip",
             "areas": ["Memory"],
@@ -1130,7 +1130,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": 101172,
+            "id": "101172",
             "type": "UnityEngine.SortingLayer",
             "method": "layers",
             "areas": ["Memory"],
@@ -1138,7 +1138,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101173,
+            "id": "101173",
             "type": "UnityEngine.TextAsset",
             "method": "bytes",
             "areas": ["Memory"],
@@ -1146,7 +1146,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101175,
+            "id": "101175",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "deviceToken",
             "areas": ["Memory"],
@@ -1156,7 +1156,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": 101176,
+            "id": "101176",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "scheduledLocalNotifications",
             "areas": ["Memory"],
@@ -1166,7 +1166,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": 101177,
+            "id": "101177",
             "type": "UnityEngine.Sprite",
             "method": "vertices",
             "areas": ["Memory"],
@@ -1174,7 +1174,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101178,
+            "id": "101178",
             "type": "UnityEngine.Sprite",
             "method": "triangles",
             "areas": ["Memory"],
@@ -1182,7 +1182,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101179,
+            "id": "101179",
             "type": "UnityEngine.Sprite",
             "method": "uv",
             "areas": ["Memory"],
@@ -1190,7 +1190,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101180,
+            "id": "101180",
             "type": "UnityEngine.SocialPlatforms.ILocalUser",
             "method": "friends",
             "areas": ["Memory"],
@@ -1198,7 +1198,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101181,
+            "id": "101181",
             "type": "UnityEngine.SocialPlatforms.ILeaderboard",
             "method": "scores",
             "areas": ["Memory"],
@@ -1206,7 +1206,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101182,
+            "id": "101182",
             "type": "UnityEngine.GUIStyleState",
             "method": "scaledBackgrounds",
             "areas": ["Memory"],
@@ -1214,7 +1214,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101183,
+            "id": "101183",
             "type": "UnityEngine.EdgeCollider2D",
             "method": "points",
             "areas": ["Memory"],
@@ -1222,7 +1222,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101184,
+            "id": "101184",
             "type": "UnityEngine.PolygonCollider2D",
             "method": "points",
             "areas": ["Memory"],
@@ -1230,7 +1230,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101185,
+            "id": "101185",
             "type": "UnityEngine.Terrain",
             "method": "activeTerrains",
             "areas": ["Memory"],
@@ -1238,7 +1238,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101186,
+            "id": "101186",
             "type": "UnityEngine.TerrainData",
             "method": "detailPrototypes",
             "areas": ["Memory"],
@@ -1246,7 +1246,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101187,
+            "id": "101187",
             "type": "UnityEngine.TerrainData",
             "method": "treePrototypes",
             "areas": ["Memory"],
@@ -1254,7 +1254,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101188,
+            "id": "101188",
             "type": "UnityEngine.TerrainData",
             "method": "splatPrototypes",
             "areas": ["Memory"],
@@ -1262,7 +1262,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101189,
+            "id": "101189",
             "type": "UnityEngine.TerrainData",
             "method": "terrainLayers",
             "areas": ["Memory"],
@@ -1270,7 +1270,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101190,
+            "id": "101190",
             "type": "UnityEngine.Tilemaps.TileAnimationData",
             "method": "animatedSprites",
             "areas": ["Memory"],
@@ -1278,7 +1278,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101191,
+            "id": "101191",
             "type": "UnityEngine.UIElements.UxmlAttributeDescription",
             "method": "obsoleteNames",
             "areas": ["Memory"],
@@ -1287,7 +1287,7 @@
             "minimumVersion": "2019.1"
         },
         {
-            "id": 101200,
+            "id": "101200",
             "type": "UnityEngine.Networking.IMultipartFormSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1295,7 +1295,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101201,
+            "id": "101201",
             "type": "UnityEngine.Networking.MultipartFormDataSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1303,7 +1303,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101202,
+            "id": "101202",
             "type": "UnityEngine.Networking.MultipartFormFileSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1311,7 +1311,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101203,
+            "id": "101203",
             "type": "UnityEngine.WWWForm",
             "method": "data",
             "areas": ["Memory"],
@@ -1319,7 +1319,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101204,
+            "id": "101204",
             "type": "UnityEngine.Networking.DownloadHandler",
             "method": "data",
             "areas": ["Memory"],
@@ -1327,7 +1327,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101208,
+            "id": "101208",
             "type": "UnityEngine.Networking.UploadHandler",
             "method": "data",
             "areas": ["Memory"],
@@ -1335,7 +1335,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101215,
+            "id": "101215",
             "type": "UnityEngine.Networking.NetworkMigrationManager",
             "method": "peers",
             "areas": ["Memory"],
@@ -1344,7 +1344,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": 101216,
+            "id": "101216",
             "type": "UnityEngine.Networking.NetworkServerSimple",
             "method": "messageBuffer",
             "areas": ["Memory"],
@@ -1353,7 +1353,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": 101217,
+            "id": "101217",
             "type": "UnityEngine.WWW",
             "method": "bytes",
             "areas": ["Memory"],
@@ -1361,7 +1361,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101219,
+            "id": "101219",
             "type": "UnityEngine.XR.XRSettings",
             "method": "supportedDevices",
             "areas": ["Memory"],
@@ -1369,7 +1369,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101220,
+            "id": "101220",
             "type": "UnityEngine.TestTools.Constraints.AllocatingGCMemoryConstraint",
             "method": "Arguments",
             "areas": ["Memory"],
@@ -1377,7 +1377,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101221,
+            "id": "101221",
             "type": "UnityEngine.TestTools.UnityPlatformAttribute",
             "method": "include",
             "areas": ["Memory"],
@@ -1385,7 +1385,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101222,
+            "id": "101222",
             "type": "UnityEngine.TestTools.UnityPlatformAttribute",
             "method": "exclude",
             "areas": ["Memory"],
@@ -1393,7 +1393,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": 101223,
+            "id": "101223",
             "type": "UnityEngine.GameObject",
             "method": "tag",
             "areas": ["Memory"],
@@ -1401,7 +1401,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer using GameObject.CompareTag() instead, as this does not result in managed allocations."
         },
         {
-            "id": 101224,
+            "id": "101224",
             "type": "UnityEngine.Object",
             "method": "Instantiate",
             "areas": ["CPU"],
@@ -1409,7 +1409,7 @@
             "solution": "Try to avoid calling Object.Instantiate frequently-updated code."
         },
         {
-            "id": 101225,
+            "id": "101225",
             "type": "UnityEngine.GameObject",
             "method": "AddComponent",
             "areas": ["CPU"],
@@ -1417,7 +1417,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer instantiating GameObjects from Prefabs will all the necessary components instead."
         },
         {
-            "id": 101226,
+            "id": "101226",
             "type": "System.String",
             "method": "Concat",
             "areas": ["Memory"],
@@ -1425,25 +1425,25 @@
             "solution": "Try to avoid concatenating strings in frequently-updated code. Prefer using a StringBuilder instead, as this minimizes managed allocations."
         },
         {
-          "id": 101227,
-          "type": "UnityEngine.Shader",
+          "id": "101227",
+            "type": "UnityEngine.Shader",
           "method": "WarmupAllShaders",
           "areas": ["CPU"],
-          "critical": true,
+          "critical": "true",
           "problem": "WarmupAllShaders does not work properly on Metal and Vulkan. This might result in unexpected CPU spikes due to shader compilation.",
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader used at runtime."
         },
         {
-          "id": 101228,
+          "id": "101228",
           "type": "UnityEngine.ShaderVariantCollection",
           "method": "WarmUp",
           "areas": ["CPU"],
-          "critical": true,
+          "critical": "true",
           "problem": "WarmUp does not work properly on Metal and Vulkan. This might result in unexpected CPU spikes due to shader compilation.",
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader variant used at runtime."
         },
         {
-          "id": 101229,
+          "id": "101229",
           "type": "UnityEngine.Component",
           "method": "tag",
           "areas": ["Memory"],
@@ -1451,7 +1451,7 @@
           "solution": "Try to avoid getting this property in frequently-updated code. Prefer using CompareTag() instead, as this does not result in managed allocations."
         },
         {
-          "id": 101230,
+          "id": "101230",
           "type": "System.DateTime",
           "method": "Now",
           "areas": ["CPU"],
@@ -1459,7 +1459,7 @@
           "solution": "Try to avoid using this method in frequently-updated code. Prefer UnityEngine.Time.time or, if precise time is needed, use DateTime.UtcNow."
         },
         {
-          "id": 101231,
+          "id": "101231",
           "type": "UnityEngine.Object",
           "method": "name",
           "areas": ["Memory"],

--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -1,7 +1,7 @@
 {
     "Items": [
         {
-            "id": "CD0000",
+            "id": "PAC0000",
             "type": "UnityEngine.Camera",
             "method": "main",
             "areas": ["CPU"],
@@ -10,7 +10,7 @@
             "maximumVersion": "2019.4.8"
         },
         {
-            "id": "CD0001",
+            "id": "PAC0001",
             "type": "UnityEngine.WebCamTexture",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -18,7 +18,7 @@
             "solution": "Use WebCamTexture.GetPixels32() instead."
         },
         {
-            "id": "CD0002",
+            "id": "PAC0002",
             "type": "UnityEngine.WebCamTexture",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -26,7 +26,7 @@
             "solution": "Ensure that you pass an array of Color32[] to this API method for it to fill out, to avoid creating a new array every time the method is called."
         },
         {
-            "id": "CD0003",
+            "id": "PAC0003",
             "type": "UnityEngine.GeometryUtility",
             "method": "CalculateFrustumPlanes",
             "areas": ["Memory"],
@@ -34,7 +34,7 @@
             "solution": "Ensure that you use the CalculateFrustumPlanes(Matrix4x4 worldToProjectionMatrix, Plane[] planes) version of this API method, in order to be able to pass a pre-allocated Array of Planes."
         },
         {
-            "id": "CD0004",
+            "id": "PAC0004",
             "type": "UnityEngine.Resources",
             "method": "FindObjectsOfTypeAll",
             "areas": ["Memory"],
@@ -42,7 +42,7 @@
             "solution": "Use Resources.FindObjectsOfTypeNonAlloc() instead."
         },
         {
-            "id": "CD0005",
+            "id": "PAC0005",
             "type": "UnityEngine.Texture2D",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -50,7 +50,7 @@
             "solution": "Use Texture2D.GetRawTextureData() instead. This method returns a NativeArray of pixel data, and so does not allocate managed memory."
         },
         {
-            "id": "CD0006",
+            "id": "PAC0006",
             "type": "UnityEngine.Texture2D",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -58,7 +58,7 @@
             "solution": "Use Texture2D.GetRawTextureData() instead. This method returns a NativeArray of pixel data, and so does not allocate managed memory."
         },
         {
-            "id": "CD0007",
+            "id": "PAC0007",
             "type": "UnityEngine.Rigidbody",
             "method": "SweepTestAll",
             "areas": ["Memory"],
@@ -66,7 +66,7 @@
             "solution": "Use Rigidbody.SweepTestNonAlloc() instead."
         },
         {
-            "id": "CD0008",
+            "id": "PAC0008",
             "type": "UnityEngine.Physics",
             "method": "RaycastAll",
             "areas": ["Memory"],
@@ -74,7 +74,7 @@
             "solution": "Use Physics.RaycastNonAlloc() instead."
         },
         {
-            "id": "CD0009",
+            "id": "PAC0009",
             "type": "UnityEngine.Physics",
             "method": "CapsuleCastAll",
             "areas": ["Memory"],
@@ -82,7 +82,7 @@
             "solution": "Use Physics.CapsuleCastNonAlloc() instead."
         },
         {
-            "id": "CD0010",
+            "id": "PAC0010",
             "type": "UnityEngine.Physics",
             "method": "SphereCastAll",
             "areas": ["Memory"],
@@ -90,7 +90,7 @@
             "solution": "Use Physics.SphereCastNonAlloc() instead."
         },
         {
-            "id": "CD0011",
+            "id": "PAC0011",
             "type": "UnityEngine.Physics",
             "method": "BoxCastAll",
             "areas": ["Memory"],
@@ -98,7 +98,7 @@
             "solution": "Use Physics.BoxCastNonAlloc() instead."
         },
         {
-            "id": "CD0012",
+            "id": "PAC0012",
             "type": "UnityEngine.Physics",
             "method": "OverlapCapsule",
             "areas": ["Memory"],
@@ -106,7 +106,7 @@
             "solution": "Use Physics.OverlapCapsuleNonAlloc() instead."
         },
         {
-            "id": "CD0013",
+            "id": "PAC0013",
             "type": "UnityEngine.Physics",
             "method": "OverlapSphere",
             "areas": ["Memory"],
@@ -114,7 +114,7 @@
             "solution": "Use Physics.OverlapSphereNonAlloc() instead."
         },
         {
-            "id": "CD0014",
+            "id": "PAC0014",
             "type": "UnityEngine.Physics",
             "method": "OverlapBox",
             "areas": ["Memory"],
@@ -122,7 +122,7 @@
             "solution": "Use Physics.OverlapBoxNonAlloc() instead."
         },
         {
-            "id": "CD0015",
+            "id": "PAC0015",
             "type": "UnityEngine.Physics2D",
             "method": "LinecastAll",
             "areas": ["Memory"],
@@ -130,7 +130,7 @@
             "solution": "Use Physics2D.LinecastNonAlloc() instead."
         },
         {
-            "id": "CD0016",
+            "id": "PAC0016",
             "type": "UnityEngine.Physics2D",
             "method": "RaycastAll",
             "areas": ["Memory"],
@@ -138,7 +138,7 @@
             "solution": "Use Physics2D.RaycastNonAlloc() instead."
         },
         {
-            "id": "CD0017",
+            "id": "PAC0017",
             "type": "UnityEngine.Physics2D",
             "method": "CircleCastAll",
             "areas": ["Memory"],
@@ -146,7 +146,7 @@
             "solution": "Use Physics2D.CircleCastNonAlloc() instead."
         },
         {
-            "id": "CD0018",
+            "id": "PAC0018",
             "type": "UnityEngine.Physics2D",
             "method": "BoxCastAll",
             "areas": ["Memory"],
@@ -154,7 +154,7 @@
             "solution": "Use Physics2D.BoxCastNonAlloc() instead."
         },
         {
-            "id": "CD0019",
+            "id": "PAC0019",
             "type": "UnityEngine.Physics2D",
             "method": "CapsuleCastAll",
             "areas": ["Memory"],
@@ -162,7 +162,7 @@
             "solution": "Use Physics2D.CapsuleCastNonAlloc() instead."
         },
         {
-            "id": "CD0020",
+            "id": "PAC0020",
             "type": "UnityEngine.Physics2D",
             "method": "GetRayIntersectionAll",
             "areas": ["Memory"],
@@ -170,7 +170,7 @@
             "solution": "Use Physics2D.GetRayIntersectionNonAlloc() instead."
         },
         {
-            "id": "CD0021",
+            "id": "PAC0021",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapPointAll",
             "areas": ["Memory"],
@@ -178,7 +178,7 @@
             "solution": "Use Physics2D.OverlapPointNonAlloc() instead."
         },
         {
-            "id": "CD0022",
+            "id": "PAC0022",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapCircleAll",
             "areas": ["Memory"],
@@ -186,7 +186,7 @@
             "solution": "Use Physics2D.OverlapCircleNonAlloc() instead."
         },
         {
-            "id": "CD0023",
+            "id": "PAC0023",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapBoxAll",
             "areas": ["Memory"],
@@ -194,7 +194,7 @@
             "solution": "Use Physics2D.OverlapBoxNonAlloc() instead."
         },
         {
-            "id": "CD0024",
+            "id": "PAC0024",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapAreaAll",
             "areas": ["Memory"],
@@ -202,7 +202,7 @@
             "solution": "Use Physics2D.OverlapAreaNonAlloc() instead."
         },
         {
-            "id": "CD0025",
+            "id": "PAC0025",
             "type": "UnityEngine.Physics2D",
             "method": "OverlapCapsuleAll",
             "areas": ["Memory"],
@@ -210,7 +210,7 @@
             "solution": "Use Physics2D.OverlapCapsuleNonAlloc() instead."
         },
         {
-            "id": "CD0026",
+            "id": "PAC0026",
             "type": "UnityEngine.Component",
             "method": "GetComponentsInChildren",
             "areas": ["Memory"],
@@ -218,7 +218,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInChildren() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "CD0027",
+            "id": "PAC0027",
             "type": "UnityEngine.Component",
             "method": "GetComponentsInParent",
             "areas": ["Memory"],
@@ -226,7 +226,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInParent() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "CD0028",
+            "id": "PAC0028",
             "type": "UnityEngine.GameObject",
             "method": "GetComponentsInChildren",
             "areas": ["Memory"],
@@ -234,7 +234,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInChildren() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "CD0029",
+            "id": "PAC0029",
             "type": "UnityEngine.GameObject",
             "method": "GetComponentsInParent",
             "areas": ["Memory"],
@@ -242,7 +242,7 @@
             "solution": "Ensure you are using one of the versions of GameObject.GetComponentsInParent() which accepts a List<T> as a parameter and populates it with the components it finds."
         },
         {
-            "id": "CD0030",
+            "id": "PAC0030",
             "type": "UnityEngine.Collider",
             "method": "OnTriggerStay",
             "areas": ["CPU"],
@@ -250,7 +250,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0031",
+            "id": "PAC0031",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnTriggerStay",
             "areas": ["CPU"],
@@ -258,7 +258,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0032",
+            "id": "PAC0032",
             "type": "UnityEngine.Collider2D",
             "method": "OnTriggerStay2D",
             "areas": ["CPU"],
@@ -266,7 +266,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay2D() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0033",
+            "id": "PAC0033",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnTriggerStay2D",
             "areas": ["CPU"],
@@ -274,7 +274,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnTriggerStay2D() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0034",
+            "id": "PAC0034",
             "type": "UnityEngine.Collider",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -282,7 +282,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0035",
+            "id": "PAC0035",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -290,7 +290,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0036",
+            "id": "PAC0036",
             "type": "UnityEngine.Rigidbody",
             "method": "OnCollisionStay",
             "areas": ["CPU"],
@@ -298,7 +298,7 @@
             "solution": "Profile CPU performance to look for bottlenecks, examine the contents of all OnCollisionStay() methods, and consider refactoring code to not use them."
         },
         {
-            "id": "CD0037",
+            "id": "PAC0037",
             "type": "UnityEngine.ImageConversion",
             "method": "LoadImage",
             "areas": ["Memory"],
@@ -306,7 +306,7 @@
             "solution": "If a CPU-accessible copy of the texture is not required, ensure that the markNonReadable flag passed into the method is set to true."
         },
         {
-            "id": "CD0039",
+            "id": "PAC0039",
             "type": "UnityEngine.Renderer",
             "method": "material",
             "areas": ["GPU"],
@@ -314,7 +314,7 @@
             "solution": "If possible, use Renderer.sharedMaterial instead."
         },
         {
-            "id": "CD0051",
+            "id": "PAC0051",
             "type": "UnityEngine.ComputeBuffer",
             "method": "GetData",
             "areas": ["CPU"],
@@ -322,7 +322,7 @@
             "solution": "Avoid reading back from ComputeBuffers if it is at all possible. If it's unavoidable, profile your project carefully and regularly to monitor the performance impact."
         },
         {
-            "id": "CD0052",
+            "id": "PAC0052",
             "type": "UnityEngine.Texture2D",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -330,7 +330,7 @@
             "solution": "Use Texture2D.SetPixels32() or GetRawTextureData()/Apply() instead."
         },
         {
-            "id": "CD0053",
+            "id": "PAC0053",
             "type": "UnityEngine.Texture3D",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -338,7 +338,7 @@
             "solution": "Use Texture3D.SetPixels32() instead."
         },
         {
-            "id": "CD0054",
+            "id": "PAC0054",
             "type": "UnityEngine.Texture2DArray",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -346,7 +346,7 @@
             "solution": "Use Texture2DArray.SetPixels32() instead."
         },
         {
-            "id": "CD0055",
+            "id": "PAC0055",
             "type": "UnityEngine.CubemapArray",
             "method": "SetPixels",
             "areas": ["CPU"],
@@ -354,7 +354,7 @@
             "solution": "Use CubemapArray.SetPixels32() instead."
         },
         {
-            "id": "CD0056",
+            "id": "PAC0056",
             "type": "UnityEngine.GameObject",
             "method": "SendMessage",
             "areas": ["CPU"],
@@ -362,7 +362,7 @@
             "solution": "Implement a custom system to replace SendMessage - get the components you want to send messages and call methods directly on them."
         },
         {
-            "id": "CD0057",
+            "id": "PAC0057",
             "type": "UnityEngine.Component",
             "method": "SendMessage",
             "areas": ["CPU"],
@@ -370,7 +370,7 @@
             "solution": "Implement a custom system to replace SendMessage - get the components you want to send messages and call methods directly on them."
         },
         {
-            "id": "CD0058",
+            "id": "PAC0058",
             "type": "UnityEngine.MonoBehaviour",
             "method": "OnGUI",
             "areas": ["CPU"],
@@ -378,7 +378,7 @@
             "solution": "Remove all OnGUI() methods from the project code."
         },
         {
-            "id": "CD0059",
+            "id": "PAC0059",
             "type": "UnityEngine.AI.NavMeshPath",
             "method": "corners",
             "areas": ["Memory"],
@@ -386,7 +386,7 @@
             "solution": "Use AI.NavMeshPath.GetCornersNonAlloc() instead"
         },
         {
-            "id": "CD0060",
+            "id": "PAC0060",
             "type": "UnityEngine.Animator",
             "method": "parameters",
             "areas": ["Memory"],
@@ -394,7 +394,7 @@
             "solution": "Use Animator.GetParameter() instead."
         },
         {
-            "id": "CD0061",
+            "id": "PAC0061",
             "type": "UnityEngine.Animations.ParentConstraint",
             "method": "translationOffsets",
             "areas": ["Memory"],
@@ -402,7 +402,7 @@
             "solution": "Use Animations.ParentConstraint.GetTranslationOffset() instead."
         },
         {
-            "id": "CD0062",
+            "id": "PAC0062",
             "type": "UnityEngine.Animations.ParentConstraint",
             "method": "rotationOffsets",
             "areas": ["Memory"],
@@ -410,7 +410,7 @@
             "solution": "Use Animations.ParentConstraint.GetRotationOffset() instead."
         },
         {
-            "id": "CD0063",
+            "id": "PAC0063",
             "type": "UnityEngine.AnimationCurve",
             "method": "keys",
             "areas": ["Memory"],
@@ -418,7 +418,7 @@
             "solution": "Use AnimationCurve.AddKey()/MoveKey()/RemoveKey() instead."
         },
         {
-            "id": "CD0066",
+            "id": "PAC0066",
             "type": "UnityEngine.Camera",
             "method": "allCameras",
             "areas": ["Memory"],
@@ -426,7 +426,7 @@
             "solution": "Use Camera.GetAllCameras() instead."
         },
         {
-            "id": "CD0067",
+            "id": "PAC0067",
             "type": "UnityEngine.Mesh",
             "method": "boneWeights",
             "areas": ["Memory"],
@@ -434,7 +434,7 @@
             "solution": "Use Mesh.GetAllBoneWeights() instead. This method returns a NativeArray of BoneWeight1, and so does not allocate managed memory."
         },
         {
-            "id": "CD0068",
+            "id": "PAC0068",
             "type": "UnityEngine.Mesh",
             "method": "bindposes",
             "areas": ["Memory"],
@@ -442,7 +442,7 @@
             "solution": "Use Mesh.GetBindposes() instead."
         },
         {
-            "id": "CD0069",
+            "id": "PAC0069",
             "type": "UnityEngine.Mesh",
             "method": "vertices",
             "areas": ["Memory"],
@@ -450,7 +450,7 @@
             "solution": "Use Mesh.GetVertices() instead."
         },
         {
-            "id": "CD0070",
+            "id": "PAC0070",
             "type": "UnityEngine.Mesh",
             "method": "normals",
             "areas": ["Memory"],
@@ -458,7 +458,7 @@
             "solution": "Use Mesh.GetNormals() instead."
         },
         {
-            "id": "CD0071",
+            "id": "PAC0071",
             "type": "UnityEngine.Mesh",
             "method": "tangents",
             "areas": ["Memory"],
@@ -466,7 +466,7 @@
             "solution": "Use Mesh.GetTangents() instead."
         },
         {
-            "id": "CD0072",
+            "id": "PAC0072",
             "type": "UnityEngine.Mesh",
             "method": "uv",
             "areas": ["Memory"],
@@ -474,7 +474,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0073",
+            "id": "PAC0073",
             "type": "UnityEngine.Mesh",
             "method": "uv1",
             "areas": ["Memory"],
@@ -482,7 +482,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0074",
+            "id": "PAC0074",
             "type": "UnityEngine.Mesh",
             "method": "uv2",
             "areas": ["Memory"],
@@ -490,7 +490,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0075",
+            "id": "PAC0075",
             "type": "UnityEngine.Mesh",
             "method": "uv3",
             "areas": ["Memory"],
@@ -498,7 +498,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0076",
+            "id": "PAC0076",
             "type": "UnityEngine.Mesh",
             "method": "uv4",
             "areas": ["Memory"],
@@ -506,7 +506,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0077",
+            "id": "PAC0077",
             "type": "UnityEngine.Mesh",
             "method": "uv5",
             "areas": ["Memory"],
@@ -514,7 +514,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0078",
+            "id": "PAC0078",
             "type": "UnityEngine.Mesh",
             "method": "uv6",
             "areas": ["Memory"],
@@ -522,7 +522,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0079",
+            "id": "PAC0079",
             "type": "UnityEngine.Mesh",
             "method": "uv7",
             "areas": ["Memory"],
@@ -530,7 +530,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0080",
+            "id": "PAC0080",
             "type": "UnityEngine.Mesh",
             "method": "uv8",
             "areas": ["Memory"],
@@ -538,7 +538,7 @@
             "solution": "Use Mesh.GetUVs() instead."
         },
         {
-            "id": "CD0081",
+            "id": "PAC0081",
             "type": "UnityEngine.Mesh",
             "method": "colors",
             "areas": ["Memory"],
@@ -546,7 +546,7 @@
             "solution": "Use Mesh.GetColors() instead."
         },
         {
-            "id": "CD0082",
+            "id": "PAC0082",
             "type": "UnityEngine.Mesh",
             "method": "colors32",
             "areas": ["Memory"],
@@ -554,7 +554,7 @@
             "solution": "Use Mesh.GetColors() instead."
         },
         {
-            "id": "CD0083",
+            "id": "PAC0083",
             "type": "UnityEngine.Mesh",
             "method": "triangles",
             "areas": ["Memory"],
@@ -562,7 +562,7 @@
             "solution": "Use Mesh.GetTriangles() instead."
         },
         {
-            "id": "CD0084",
+            "id": "PAC0084",
             "type": "UnityEngine.Renderer",
             "method": "materials",
             "areas": ["Memory"],
@@ -570,7 +570,7 @@
             "solution": "Use Renderer.GetMaterials() instead."
         },
         {
-            "id": "CD0085",
+            "id": "PAC0085",
             "type": "UnityEngine.Renderer",
             "method": "sharedMaterials",
             "areas": ["Memory"],
@@ -578,7 +578,7 @@
             "solution": "Use Renderer.GetSharedMaterials() instead."
         },
         {
-            "id": "CD0094",
+            "id": "PAC0094",
             "type": "UnityEngine.Input",
             "method": "touches",
             "areas": ["Memory"],
@@ -586,7 +586,7 @@
             "solution": "Use Input.GetTouch() instead."
         },
         {
-            "id": "CD0095",
+            "id": "PAC0095",
             "type": "UnityEngine.Input",
             "method": "accelerationEvents",
             "areas": ["Memory"],
@@ -594,7 +594,7 @@
             "solution": "Use Input.GetAccelerationEvent() instead."
         },
         {
-            "id": "CD0096",
+            "id": "PAC0096",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "localNotifications",
             "areas": ["Memory"],
@@ -604,7 +604,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "CD0097",
+            "id": "PAC0097",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "remoteNotifications",
             "areas": ["Memory"],
@@ -614,7 +614,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "CD0100",
+            "id": "PAC0100",
             "type": "UnityEngine.GUISkin",
             "method": "customStyles",
             "areas": ["Memory"],
@@ -622,7 +622,7 @@
             "solution": "Use GUISkin.GetStyle() or GUISkin.FindStyle() instead."
         },
         {
-            "id": "CD0103",
+            "id": "PAC0103",
             "type": "UnityEngine.Collision",
             "method": "contacts",
             "areas": ["Memory"],
@@ -630,7 +630,7 @@
             "solution": "Use Collision.GetContacts() instead."
         },
         {
-            "id": "CD0104",
+            "id": "PAC0104",
             "type": "UnityEngine.Collision2D",
             "method": "contacts",
             "areas": ["Memory"],
@@ -639,7 +639,7 @@
         },
 
         {
-            "id": "CD0110",
+            "id": "PAC0110",
             "type": "UnityEngine.TerrainData",
             "method": "treeInstances",
             "areas": ["Memory"],
@@ -647,7 +647,7 @@
             "solution": "Use TerrainData.GetTreeInstance() instead."
         },
         {
-            "id": "CD0111",
+            "id": "PAC0111",
             "type": "UnityEngine.TerrainData",
             "method": "alphamapTextures",
             "areas": ["Memory"],
@@ -655,7 +655,7 @@
             "solution": "Use TerrainData.GetAlphamapTexture() instead."
         },
         {
-            "id": "CD0112",
+            "id": "PAC0112",
             "type": "UnityEngine.Font",
             "method": "characterInfo",
             "areas": ["Memory"],
@@ -663,7 +663,7 @@
             "solution": "Use Font.GetCharacterInfo() instead."
         },
         {
-            "id": "CD0115",
+            "id": "PAC0115",
             "type": "UnityEngine.Animator",
             "method": "GetCurrentAnimationClipState",
             "areas": ["Memory"],
@@ -671,7 +671,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0116",
+            "id": "PAC0116",
             "type": "UnityEngine.Animator",
             "method": "GetBehaviours",
             "areas": ["Memory"],
@@ -679,7 +679,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0117",
+            "id": "PAC0117",
             "type": "UnityEngine.AssetBundle",
             "method": "LoadAssetWithSubAssets",
             "areas": ["Memory"],
@@ -687,7 +687,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0118",
+            "id": "PAC0118",
             "type": "UnityEngine.AssetBundle",
             "method": "LoadAllAssets",
             "areas": ["Memory"],
@@ -695,7 +695,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0119",
+            "id": "PAC0119",
             "type": "UnityEngine.AssetBundleManifest",
             "method": "GetAllAssetBundles",
             "areas": ["Memory"],
@@ -703,7 +703,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0120",
+            "id": "PAC0120",
             "type": "UnityEngine.Resources",
             "method": "LoadAll",
             "areas": ["Memory"],
@@ -711,7 +711,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0121",
+            "id": "PAC0121",
             "type": "UnityEngine.Texture2D",
             "method": "PackTextures",
             "areas": ["Memory"],
@@ -719,7 +719,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0122",
+            "id": "PAC0122",
             "type": "UnityEngine.Cubemap",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -727,7 +727,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0123",
+            "id": "PAC0123",
             "type": "UnityEngine.Texture3D",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -735,7 +735,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0124",
+            "id": "PAC0124",
             "type": "UnityEngine.Texture3D",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -743,7 +743,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0125",
+            "id": "PAC0125",
             "type": "UnityEngine.Texture2DArray",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -751,7 +751,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0126",
+            "id": "PAC0126",
             "type": "UnityEngine.Texture2DArray",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -759,7 +759,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0127",
+            "id": "PAC0127",
             "type": "UnityEngine.CubemapArray",
             "method": "GetPixels",
             "areas": ["Memory"],
@@ -767,7 +767,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0128",
+            "id": "PAC0128",
             "type": "UnityEngine.CubemapArray",
             "method": "GetPixels32",
             "areas": ["Memory"],
@@ -775,7 +775,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0129",
+            "id": "PAC0129",
             "type": "UnityEngine.Object",
             "method": "FindObjectsOfType",
             "areas": ["Memory"],
@@ -783,7 +783,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0130",
+            "id": "PAC0130",
             "type": "UnityEngine.Windows.Crypto",
             "method": "ComputeMD5Hash",
             "areas": ["Memory"],
@@ -791,7 +791,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0131",
+            "id": "PAC0131",
             "type": "UnityEngine.Windows.File",
             "method": "ReadAllBytes",
             "areas": ["Memory"],
@@ -799,7 +799,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0132",
+            "id": "PAC0132",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToJPG",
             "areas": ["Memory"],
@@ -807,7 +807,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0133",
+            "id": "PAC0133",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToEXR",
             "areas": ["Memory"],
@@ -815,7 +815,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0134",
+            "id": "PAC0134",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToTGA",
             "areas": ["Memory"],
@@ -823,7 +823,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0135",
+            "id": "PAC0135",
             "type": "UnityEngine.ImageConversion",
             "method": "EncodeToPNG",
             "areas": ["Memory"],
@@ -831,7 +831,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0136",
+            "id": "PAC0136",
             "type": "UnityEngine.U2D.SpriteShapeUtility",
             "method": "Generate",
             "areas": ["Memory"],
@@ -840,7 +840,7 @@
             "minimumVersion": "2019.3"
         },
         {
-            "id": "CD0138",
+            "id": "PAC0138",
             "type": "UnityEngine.AI.NavMeshTriangulation",
             "method": "layers",
             "areas": ["Memory"],
@@ -848,7 +848,7 @@
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0139",
+            "id": "PAC0139",
             "type": "UnityEngine.AnimationClip",
             "method": "events",
             "areas": ["Memory"],
@@ -856,7 +856,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0140",
+            "id": "PAC0140",
             "type": "UnityEngine.AnimatorOverrideController",
             "method": "animationClips",
             "areas": ["Memory"],
@@ -864,7 +864,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0141",
+            "id": "PAC0141",
             "type": "UnityEngine.HumanTrait",
             "method": "MuscleName",
             "areas": ["Memory"],
@@ -872,7 +872,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0142",
+            "id": "PAC0142",
             "type": "UnityEngine.HumanTrait",
             "method": "BoneName",
             "areas": ["Memory"],
@@ -880,7 +880,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0143",
+            "id": "PAC0143",
             "type": "UnityEngine.RuntimeAnimatorController",
             "method": "animationClips",
             "areas": ["Memory"],
@@ -888,7 +888,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0144",
+            "id": "PAC0144",
             "type": "UnityEngine.AssetBundleRequest",
             "method": "allAssets",
             "areas": ["Memory"],
@@ -896,7 +896,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0145",
+            "id": "PAC0145",
             "type": "UnityEngine.Microphone",
             "method": "devices",
             "areas": ["Memory"],
@@ -904,7 +904,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0146",
+            "id": "PAC0146",
             "type": "UnityEngine.WebCamDevice",
             "method": "availableResolutions",
             "areas": ["Memory"],
@@ -912,7 +912,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0147",
+            "id": "PAC0147",
             "type": "UnityEngine.WebCamTexture",
             "method": "devices",
             "areas": ["Memory"],
@@ -920,7 +920,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0148",
+            "id": "PAC0148",
             "type": "UnityEngine.Cloth",
             "method": "vertices",
             "areas": ["Memory"],
@@ -928,7 +928,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0149",
+            "id": "PAC0149",
             "type": "UnityEngine.Cloth",
             "method": "normals",
             "areas": ["Memory"],
@@ -936,7 +936,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0150",
+            "id": "PAC0150",
             "type": "UnityEngine.Cloth",
             "method": "coefficients",
             "areas": ["Memory"],
@@ -944,7 +944,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0151",
+            "id": "PAC0151",
             "type": "UnityEngine.Cloth",
             "method": "capsuleColliders",
             "areas": ["Memory"],
@@ -952,7 +952,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0152",
+            "id": "PAC0152",
             "type": "UnityEngine.Cloth",
             "method": "sphereColliders",
             "areas": ["Memory"],
@@ -960,7 +960,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0153",
+            "id": "PAC0153",
             "type": "UnityEngine.Camera",
             "method": "layerCullDistances",
             "areas": ["Memory"],
@@ -968,7 +968,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0154",
+            "id": "PAC0154",
             "type": "UnityEngine.CrashReport",
             "method": "reports",
             "areas": ["Memory"],
@@ -976,7 +976,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0155",
+            "id": "PAC0155",
             "type": "UnityEngine.Gradient",
             "method": "colorKeys",
             "areas": ["Memory"],
@@ -984,7 +984,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0156",
+            "id": "PAC0156",
             "type": "UnityEngine.Gradient",
             "method": "alphaKeys",
             "areas": ["Memory"],
@@ -992,7 +992,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0157",
+            "id": "PAC0157",
             "type": "UnityEngine.Screen",
             "method": "resolutions",
             "areas": ["Memory"],
@@ -1000,7 +1000,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0158",
+            "id": "PAC0158",
             "type": "UnityEngine.LightmapSettings",
             "method": "lightmaps",
             "areas": ["Memory"],
@@ -1008,7 +1008,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0159",
+            "id": "PAC0159",
             "type": "UnityEngine.LightProbes",
             "method": "positions",
             "areas": ["Memory"],
@@ -1016,7 +1016,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0160",
+            "id": "PAC0160",
             "type": "UnityEngine.LightProbes",
             "method": "bakedProbes",
             "areas": ["Memory"],
@@ -1024,7 +1024,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0161",
+            "id": "PAC0161",
             "type": "UnityEngine.LightProbes",
             "method": "coefficients",
             "areas": ["Memory"],
@@ -1032,7 +1032,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0162",
+            "id": "PAC0162",
             "type": "UnityEngine.QualitySettings",
             "method": "names",
             "areas": ["Memory"],
@@ -1040,7 +1040,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0163",
+            "id": "PAC0163",
             "type": "UnityEngine.Material",
             "method": "shaderKeywords",
             "areas": ["Memory"],
@@ -1048,7 +1048,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0164",
+            "id": "PAC0164",
             "type": "UnityEngine.Light",
             "method": "layerShadowCullDistances",
             "areas": ["Memory"],
@@ -1056,7 +1056,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0165",
+            "id": "PAC0165",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorRenderTargets",
             "areas": ["Memory"],
@@ -1064,7 +1064,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0166",
+            "id": "PAC0166",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorLoadActions",
             "areas": ["Memory"],
@@ -1072,7 +1072,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0167",
+            "id": "PAC0167",
             "type": "UnityEngine.Rendering.RenderTargetBinding",
             "method": "colorStoreActions",
             "areas": ["Memory"],
@@ -1080,7 +1080,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0168",
+            "id": "PAC0168",
             "type": "UnityEngine.SkinnedMeshRenderer",
             "method": "bones",
             "areas": ["Memory"],
@@ -1088,7 +1088,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0169",
+            "id": "PAC0169",
             "type": "UnityEngine.LightProbeGroup",
             "method": "probePositions",
             "areas": ["Memory"],
@@ -1096,7 +1096,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0170",
+            "id": "PAC0170",
             "type": "UnityEngine.Network",
             "method": "connections",
             "areas": ["Memory"],
@@ -1105,7 +1105,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "CD0171",
+            "id": "PAC0171",
             "type": "UnityEngine.HostData",
             "method": "ip",
             "areas": ["Memory"],
@@ -1114,7 +1114,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "CD0172",
+            "id": "PAC0172",
             "type": "UnityEngine.SortingLayer",
             "method": "layers",
             "areas": ["Memory"],
@@ -1122,7 +1122,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0173",
+            "id": "PAC0173",
             "type": "UnityEngine.TextAsset",
             "method": "bytes",
             "areas": ["Memory"],
@@ -1130,7 +1130,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0175",
+            "id": "PAC0175",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "deviceToken",
             "areas": ["Memory"],
@@ -1140,7 +1140,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "CD0176",
+            "id": "PAC0176",
             "type": "UnityEngine.iOS.NotificationServices",
             "method": "scheduledLocalNotifications",
             "areas": ["Memory"],
@@ -1150,7 +1150,7 @@
             "platforms": ["iOS"]
         },
         {
-            "id": "CD0177",
+            "id": "PAC0177",
             "type": "UnityEngine.Sprite",
             "method": "vertices",
             "areas": ["Memory"],
@@ -1158,7 +1158,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0178",
+            "id": "PAC0178",
             "type": "UnityEngine.Sprite",
             "method": "triangles",
             "areas": ["Memory"],
@@ -1166,7 +1166,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0179",
+            "id": "PAC0179",
             "type": "UnityEngine.Sprite",
             "method": "uv",
             "areas": ["Memory"],
@@ -1174,7 +1174,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0180",
+            "id": "PAC0180",
             "type": "UnityEngine.SocialPlatforms.ILocalUser",
             "method": "friends",
             "areas": ["Memory"],
@@ -1182,7 +1182,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0181",
+            "id": "PAC0181",
             "type": "UnityEngine.SocialPlatforms.ILeaderboard",
             "method": "scores",
             "areas": ["Memory"],
@@ -1190,7 +1190,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0182",
+            "id": "PAC0182",
             "type": "UnityEngine.GUIStyleState",
             "method": "scaledBackgrounds",
             "areas": ["Memory"],
@@ -1198,7 +1198,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0183",
+            "id": "PAC0183",
             "type": "UnityEngine.EdgeCollider2D",
             "method": "points",
             "areas": ["Memory"],
@@ -1206,7 +1206,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0184",
+            "id": "PAC0184",
             "type": "UnityEngine.PolygonCollider2D",
             "method": "points",
             "areas": ["Memory"],
@@ -1214,7 +1214,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0185",
+            "id": "PAC0185",
             "type": "UnityEngine.Terrain",
             "method": "activeTerrains",
             "areas": ["Memory"],
@@ -1222,7 +1222,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0186",
+            "id": "PAC0186",
             "type": "UnityEngine.TerrainData",
             "method": "detailPrototypes",
             "areas": ["Memory"],
@@ -1230,7 +1230,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0187",
+            "id": "PAC0187",
             "type": "UnityEngine.TerrainData",
             "method": "treePrototypes",
             "areas": ["Memory"],
@@ -1238,7 +1238,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0188",
+            "id": "PAC0188",
             "type": "UnityEngine.TerrainData",
             "method": "splatPrototypes",
             "areas": ["Memory"],
@@ -1246,7 +1246,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0189",
+            "id": "PAC0189",
             "type": "UnityEngine.TerrainData",
             "method": "terrainLayers",
             "areas": ["Memory"],
@@ -1254,7 +1254,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0190",
+            "id": "PAC0190",
             "type": "UnityEngine.Tilemaps.TileAnimationData",
             "method": "animatedSprites",
             "areas": ["Memory"],
@@ -1262,7 +1262,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0191",
+            "id": "PAC0191",
             "type": "UnityEngine.UIElements.UxmlAttributeDescription",
             "method": "obsoleteNames",
             "areas": ["Memory"],
@@ -1271,7 +1271,7 @@
             "minimumVersion": "2019.1"
         },
         {
-            "id": "CD0200",
+            "id": "PAC0200",
             "type": "UnityEngine.Networking.IMultipartFormSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1279,7 +1279,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0201",
+            "id": "PAC0201",
             "type": "UnityEngine.Networking.MultipartFormDataSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1287,7 +1287,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0202",
+            "id": "PAC0202",
             "type": "UnityEngine.Networking.MultipartFormFileSection",
             "method": "sectionData",
             "areas": ["Memory"],
@@ -1295,7 +1295,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0203",
+            "id": "PAC0203",
             "type": "UnityEngine.WWWForm",
             "method": "data",
             "areas": ["Memory"],
@@ -1303,7 +1303,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0204",
+            "id": "PAC0204",
             "type": "UnityEngine.Networking.DownloadHandler",
             "method": "data",
             "areas": ["Memory"],
@@ -1311,7 +1311,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0208",
+            "id": "PAC0208",
             "type": "UnityEngine.Networking.UploadHandler",
             "method": "data",
             "areas": ["Memory"],
@@ -1319,7 +1319,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0215",
+            "id": "PAC0215",
             "type": "UnityEngine.Networking.NetworkMigrationManager",
             "method": "peers",
             "areas": ["Memory"],
@@ -1328,7 +1328,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "CD0216",
+            "id": "PAC0216",
             "type": "UnityEngine.Networking.NetworkServerSimple",
             "method": "messageBuffer",
             "areas": ["Memory"],
@@ -1337,7 +1337,7 @@
             "maximumVersion": "2018.4"
         },
         {
-            "id": "CD0217",
+            "id": "PAC0217",
             "type": "UnityEngine.WWW",
             "method": "bytes",
             "areas": ["Memory"],
@@ -1345,7 +1345,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0219",
+            "id": "PAC0219",
             "type": "UnityEngine.XR.XRSettings",
             "method": "supportedDevices",
             "areas": ["Memory"],
@@ -1353,7 +1353,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0220",
+            "id": "PAC0220",
             "type": "UnityEngine.TestTools.Constraints.AllocatingGCMemoryConstraint",
             "method": "Arguments",
             "areas": ["Memory"],
@@ -1361,7 +1361,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0221",
+            "id": "PAC0221",
             "type": "UnityEngine.TestTools.UnityPlatformAttribute",
             "method": "include",
             "areas": ["Memory"],
@@ -1369,7 +1369,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0222",
+            "id": "PAC0222",
             "type": "UnityEngine.TestTools.UnityPlatformAttribute",
             "method": "exclude",
             "areas": ["Memory"],
@@ -1377,7 +1377,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-            "id": "CD0223",
+            "id": "PAC0223",
             "type": "UnityEngine.GameObject",
             "method": "tag",
             "areas": ["Memory"],
@@ -1385,7 +1385,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer using GameObject.CompareTag() instead, as this does not result in managed allocations."
         },
         {
-            "id": "CD0224",
+            "id": "PAC0224",
             "type": "UnityEngine.Object",
             "method": "Instantiate",
             "areas": ["CPU"],
@@ -1393,7 +1393,7 @@
             "solution": "Try to avoid calling Object.Instantiate frequently-updated code."
         },
         {
-            "id": "CD0225",
+            "id": "PAC0225",
             "type": "UnityEngine.GameObject",
             "method": "AddComponent",
             "areas": ["CPU"],
@@ -1401,7 +1401,7 @@
             "solution": "Try to avoid getting this property in frequently-updated code. Prefer instantiating GameObjects from Prefabs will all the necessary components instead."
         },
         {
-          "id": "CD0227",
+          "id": "PAC0227",
           "type": "UnityEngine.Shader",
           "method": "WarmupAllShaders",
           "areas": ["CPU"],
@@ -1410,7 +1410,7 @@
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader used at runtime."
         },
         {
-          "id": "CD0228",
+          "id": "PAC0228",
           "type": "UnityEngine.ShaderVariantCollection",
           "method": "WarmUp",
           "areas": ["CPU"],
@@ -1419,7 +1419,7 @@
           "solution": "Implement a shader pre-warming mechanism which renders a small triangle for each combination of vertex format and shader variant used at runtime."
         },
         {
-          "id": "CD0229",
+          "id": "PAC0229",
           "type": "UnityEngine.Component",
           "method": "tag",
           "areas": ["Memory"],
@@ -1427,7 +1427,7 @@
           "solution": "Try to avoid getting this property in frequently-updated code. Prefer using CompareTag() instead, as this does not result in managed allocations."
         },
         {
-          "id": "CD0231",
+          "id": "PAC0231",
           "type": "UnityEngine.Object",
           "method": "name",
           "areas": ["Memory"],
@@ -1435,7 +1435,7 @@
           "solution": "Try to avoid getting this property in frequently-updated code. Ideally, this property should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
-          "id": "CD1000",
+          "id": "PAC1000",
           "type": "System.Linq",
           "method": "*",
           "areas": ["Memory"],
@@ -1443,7 +1443,7 @@
           "solution": "We strongly advise against using Linq in any frequently-updated code. Ban its usage from the project entirely, or confine it to initialization code and use it sparingly."
         },
         {
-          "id": "CD1001",
+          "id": "PAC1001",
           "type": "System.Reflection",
           "method": "*",
           "areas": ["CPU"],
@@ -1451,7 +1451,7 @@
           "solution": "Remove code which relies on reflection, or minimise its usage, particularly outside of initialization."
         },
         {
-          "id": "CD1002",
+          "id": "PAC1002",
           "type": "System.String",
           "method": "Concat",
           "areas": ["Memory"],
@@ -1459,7 +1459,7 @@
           "solution": "Try to avoid concatenating strings in frequently-updated code. Prefer using a StringBuilder instead, as this minimizes managed allocations."
         },
         {
-          "id": "CD1003",
+          "id": "PAC1003",
           "type": "System.DateTime",
           "method": "Now",
           "areas": ["CPU"],
@@ -1467,7 +1467,7 @@
           "solution": "Try to avoid using this method in frequently-updated code. Prefer UnityEngine.Time.time or, if precise time is needed, use DateTime.UtcNow."
         },
         {
-          "id": "CD0232",
+          "id": "PAC0232",
           "type": "System.AppDomain",
           "method": "GetAssemblies",
           "areas": ["CPU"],

--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -1,7 +1,7 @@
 {
     "Items": [
         {
-            "id": "SD0000",
+            "id": "PAS0000",
             "description": "Player: Metal API Validation",
             "type": "UnityEditor.PlayerSettings",
             "method": "enableMetalAPIValidation",
@@ -13,7 +13,7 @@
             "minimumVersion": "2018.1"
         },
         {
-            "id": "SD0001",
+            "id": "PAS0001",
             "description": "Player: Graphics Jobs (Experimental)",
             "type": "UnityEditor.PlayerSettings",
             "method": "graphicsJobs",
@@ -23,7 +23,7 @@
             "solution": "Try enabling it and testing your application. This option spreads the task of building the render command buffer every frame across as many CPU cores as possible, rather than performing all the work in the render thread which is often a bottleneck. Note: This feature is experimental. It may not deliver a performance improvement for your project, and may introduce new crashes. Test accordingly."
         },
         {
-            "id": "SD0002",
+            "id": "PAS0002",
             "description": "Player (iOS): Accelerometer",
             "type": "UnityEditor.PlayerSettings",
             "method": "accelerometerFrequency",
@@ -34,7 +34,7 @@
             "solution": "Consider setting <b>Accelerometer Frequency</b> to Disabled if your application doesn't make use of the device's accelerometer. Disabling this option will save a tiny amount of CPU processing time."
         },
         {
-            "id": "SD0003",
+            "id": "PAS0003",
             "description": "Player (iOS): Building multiple architectures",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetArchitecture",
@@ -45,7 +45,7 @@
             "solution": "If your application isn't intended to support 32-bit iOS devices, change <b>Architecture</b> to ARM64."
         },
         {
-            "id": "SD0004",
+            "id": "PAS0004",
             "description": "Player (Android): Building multiple architectures",
             "type": "UnityEditor.PlayerSettings",
             "method": "Android.targetArchitectures",
@@ -56,7 +56,7 @@
             "solution": "If your application isn't intended to support 32-bit Android devices, disable the <b>ARMv7</b> option."
         },
         {
-            "id": "SD0005",
+            "id": "PAS0005",
             "description": "Player(iOS): Metal & OpenGLES APIs",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -67,7 +67,7 @@
             "solution": "To reduce build size, remove OpenGLES graphics API if the minimum spec target device supports Metal."
         },
         {
-            "id": "SD0006",
+            "id": "PAS0006",
             "description": "Player (iOS): Metal API",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -78,7 +78,7 @@
             "solution": "Enable Metal graphics API for better CPU Performance."
         },
         {
-            "id": "SD0007",
+            "id": "PAS0007",
             "description": "Player: Prebake Collision Meshes",
             "type": "UnityEditor.PlayerSettings",
             "method": "bakeCollisionMeshes",
@@ -88,7 +88,7 @@
             "solution": "If you are using physics in your application, consider enabling this option. Prebaked collision meshes can result in an increase in build times and sizes, but reduce loading/initialization times in your application, because serializing prebaked meshes is faster than baking them at runtime."
         },
         {
-            "id": "SD0008",
+            "id": "PAS0008",
             "description": "Player: Optimize Mesh Data",
             "type": "UnityEditor.PlayerSettings",
             "method": "stripUnusedMeshComponents",
@@ -98,7 +98,7 @@
             "solution": "Consider enabling it. This option strips out vertex channels on meshes which are not used by the materials which are applied to them. This can reduce the file size of your meshes and the time to load them, and increase GPU rendering performance. It can, however, cause problems if mesh materials are changed at runtime, since the new materials might rely on vertex channels which have been removed, and it may contribute to longer build times."
         },
         {
-            "id": "SD0009",
+            "id": "PAS0009",
             "description": "Player: Engine Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "stripEngineCode",
@@ -109,7 +109,7 @@
             "solution": "Enable <b>stripEngineCode</b> in <b>Project Settings ➔ Player ➔ Other Settings</b>"
         },
         {
-            "id": "SD0010",
+            "id": "PAS0010",
             "description": "Player (WebGL): Data Caching",
             "type": "UnityEditor.PlayerSettings+WebGL",
             "method": "dataCaching",
@@ -120,7 +120,7 @@
             "solution": "Enable <b>dataCaching</b> to cache build files in Browser cache"
         },
         {
-            "id": "SD0011",
+            "id": "PAS0011",
             "description": "Player (WebGL): Linker Target",
             "type": "UnityEditor.PlayerSettings+WebGL",
             "method": "linkerTarget",
@@ -132,7 +132,7 @@
             "minimumVersion": "2018.1"
         },
         {
-            "id": "SD0012",
+            "id": "PAS0012",
             "description": "Physics: Auto Sync Transforms",
             "type": "UnityEngine.Physics",
             "method": "autoSyncTransforms",
@@ -142,7 +142,7 @@
             "solution": "Consider disabling <b>Auto Sync Transforms</b> and testing your game to identify any areas where physics behavior is affected by the change. If there are areas of the game where more frequent synchronization is required to maintain the desired behaviour, this can be enforced by calling Physics.SyncTransforms() directly."
         },
         {
-            "id": "SD0013",
+            "id": "PAS0013",
             "description": "Physics: Layer Collision Matrix",
             "type": "UnityEngine.Physics",
             "method": "GetIgnoreLayerCollision",
@@ -152,7 +152,7 @@
             "solution": "Un-tick all of the boxes except the ones that represent collisions that should be considered by the physics system."
         },
         {
-            "id": "SD0014",
+            "id": "PAS0014",
             "description": "Physics2D: Auto Sync Transforms",
             "type": "UnityEngine.Physics2D",
             "method": "autoSyncTransforms",
@@ -162,7 +162,7 @@
             "solution": "Consider disabling <b>Auto Sync Transforms</b> and testing your game to identify any areas where physics behavior is affected by the change. If there are areas of the game where more frequent synchronization is required to maintain the desired behaviour, this can be enforced by calling Physics2D.SyncTransforms() directly."
         },
         {
-            "id": "SD0015",
+            "id": "PAS0015",
             "description": "Physics2D: Layer Collision Matrix",
             "type": "UnityEngine.Physics2D",
             "method": "GetIgnoreLayerCollision",
@@ -172,7 +172,7 @@
             "solution": "Un-tick all of the boxes except the ones that represent collisions that should be considered by the 2D physics system."
         },
         {
-            "id": "SD0016",
+            "id": "PAS0016",
             "description": "Time: Fixed Timestep",
             "type": "UnityEngine.Time",
             "method": "fixedDeltaTime",
@@ -182,7 +182,7 @@
             "solution": "We recommend setting Fixed Timestep to 0.04 when running at 30 FPS, in order to call the fixed updates at 25 Hz. The reason for having the fixed update be slightly less than the target frame rate is to avoid the “spiral of death”, in which if one frame takes longer than 33.3ms, FixedUpdate() happens multiple times on the next frame to catch up, pushing that frame time over as well, and permanently locking the game into a state where it cannot reach the desired frame rate because FixedUpdate() is constantly trying to catch up."
         },
         {
-            "id": "SD0017",
+            "id": "PAS0017",
             "description": "Time: Maximum Allowed Timestep",
             "type": "UnityEngine.Time",
             "method": "maximumDeltaTime",
@@ -192,7 +192,7 @@
             "solution": "Consider reducing <b>Maximum Allowed Timestep</b> to a time that can be comfortably accommodated within your project's target frame rate."
         },
         {
-            "id": "SD0018",
+            "id": "PAS0018",
             "description": "Quality: Quality Levels",
             "type": "UnityEngine.QualitySettings",
             "method": "GetQualityLevel",
@@ -202,7 +202,7 @@
             "solution": "Check the quality setting for each platform the project supports in the grid - it's the level with the green tick. Remove quality levels you are not using, to make the Quality Settings simpler to see and edit. Adjust the setting for each platform if necessary, then select the appropriate levels to examine their settings in the panel below."
         },
         {
-            "id": "SD0019",
+            "id": "PAS0019",
             "description": "Quality: Texture Quality",
             "type": "UnityEngine.QualitySettings",
             "method": "masterTextureLimit",
@@ -212,7 +212,7 @@
             "solution": "For devices which must use lower-resolution versions of textures, consider creating these lower resolution textures separately, and choosing the appropriate content to load at runtime using AssetBundle variants."
         },
         {
-            "id": "SD0020",
+            "id": "PAS0020",
             "description": "Quality: Async Upload Time Slice",
             "type": "UnityEngine.QualitySettings",
             "method": "asyncUploadTimeSlice",
@@ -222,7 +222,7 @@
             "solution": "If the project encounters long loading times when loading large amount of texture and/or mesh data, experiment with increasing this value to see if it allows content to be uploaded to the GPU more quickly."
         },
         {
-            "id": "SD0021",
+            "id": "PAS0021",
             "description": "Quality: Async Upload Buffer Size",
             "type": "UnityEngine.QualitySettings",
             "method": "asyncUploadBufferSize",
@@ -232,7 +232,7 @@
             "solution": "If the project encounters long loading times when loading large amount of texture and/or mesh data, experiment with increasing this value to see if it allows content to be uploaded to the GPU more quickly. This is most likely to help if you are loading large textures. Note that this setting controls a buffer size in megabytes, so exercise caution if memory is limited in your application."
         },
         {
-            "id": "SD0022",
+            "id": "PAS0022",
             "description": "Graphics: Shader Quality",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -242,7 +242,7 @@
             "solution": "Unless you support devices with a very wide range of capabilities for a particular platform, consider editing the platform in Graphics Settings to use the same shader quality setting across all Graphics Tiers."
         },
         {
-            "id": "SD0023",
+            "id": "PAS0023",
             "description": "Graphics: Forward Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -252,7 +252,7 @@
             "solution": "This rendering path is suitable for games with simple rendering and lighting requirements - for instance, 2D games, or games which mainly use baked lighting. If the project makes use of a more than a few dynamic lights, consider experimenting with changing <b>Rendering Path</b> to Deferred to see whether doing so improves GPU rendering times."
         },
         {
-            "id": "SD0024",
+            "id": "PAS0024",
             "description": "Graphics: Deferred Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -262,7 +262,7 @@
             "solution": "This rendering path is suitable for games with more complex rendering requirements - for instance, games that make uses of dynamic lighting or certain types of fullscreen post-processing effects. If the project doesn't make use of such rendering techniques, consider experimenting with changing <b>Rendering Path</b> to Forward to see whether doing so improves GPU rendering times."
         },
         {
-            "id": "SD0025",
+            "id": "PAS0025",
             "description": "Player (Android): Managed Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetManagedStrippingLevel",
@@ -273,7 +273,7 @@
             "solution": "Set managed stripping level to Medium or High."
         },
         {
-            "id": "SD0026",
+            "id": "PAS0026",
             "description": "Player (iOS): Managed Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetManagedStrippingLevel",
@@ -284,7 +284,7 @@
             "solution": "Set managed stripping level to Medium or High."
         },
         {
-            "id": "SD0027",
+            "id": "PAS0027",
             "description": "Player: Mipmap Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "mipStripping",
@@ -295,7 +295,7 @@
             "minimumVersion": "2020.2"
         },
         {
-            "id": "SD0028",
+            "id": "PAS0028",
             "description": "Physics: Reuse Collision Callbacks",
             "type": "UnityEngine.Physics",
             "method": "reuseCollisionCallbacks",
@@ -306,7 +306,7 @@
             "minimumVersion": "2018.3"
         },
         {
-            "id": "SD0029",
+            "id": "PAS0029",
             "description": "Player: Splash Screen",
             "type": "UnityEditor.PlayerSettings+SplashScreen",
             "method": "show",
@@ -316,7 +316,7 @@
             "solution": "Disable the Splash Screen option in <b>Project Settings ➔ Player ➔ Splash Image ➔ Show Splash Screen</b>."
         },
         {
-            "id": "SD0030",
+            "id": "PAS0030",
             "description": "Player (Android): Optimized Frame Pacing",
             "type": "UnityEditor.PlayerSettings+Android",
             "method": "optimizedFramePacing",
@@ -328,7 +328,7 @@
             "minimumVersion": "2019.2"
         },
         {
-            "id": "SD0031",
+            "id": "PAS0031",
             "description": "Player (Android): Vulkan API",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",

--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -1,7 +1,7 @@
 {
     "Items": [
         {
-            "id": 201000,
+            "id": "201000",
             "description": "Player: Metal API Validation",
             "type": "UnityEditor.PlayerSettings",
             "method": "enableMetalAPIValidation",
@@ -13,7 +13,7 @@
             "minimumVersion": "2018.1"
         },
         {
-            "id": 201001,
+            "id": "201001",
             "description": "Player: Graphics Jobs (Experimental)",
             "type": "UnityEditor.PlayerSettings",
             "method": "graphicsJobs",
@@ -23,7 +23,7 @@
             "solution": "Try enabling it and testing your application. This option spreads the task of building the render command buffer every frame across as many CPU cores as possible, rather than performing all the work in the render thread which is often a bottleneck. Note: This feature is experimental. It may not deliver a performance improvement for your project, and may introduce new crashes. Test accordingly."
         },
         {
-            "id": 201002,
+            "id": "201002",
             "description": "Player (iOS): Accelerometer",
             "type": "UnityEditor.PlayerSettings",
             "method": "accelerometerFrequency",
@@ -34,7 +34,7 @@
             "solution": "Consider setting <b>Accelerometer Frequency</b> to Disabled if your application doesn't make use of the device's accelerometer. Disabling this option will save a tiny amount of CPU processing time."
         },
         {
-            "id": 201003,
+            "id": "201003",
             "description": "Player (iOS): Building multiple architectures",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetArchitecture",
@@ -45,7 +45,7 @@
             "solution": "If your application isn't intended to support 32-bit iOS devices, change <b>Architecture</b> to ARM64."
         },
         {
-            "id": 201004,
+            "id": "201004",
             "description": "Player (Android): Building multiple architectures",
             "type": "UnityEditor.PlayerSettings",
             "method": "Android.targetArchitectures",
@@ -56,7 +56,7 @@
             "solution": "If your application isn't intended to support 32-bit Android devices, disable the <b>ARMv7</b> option."
         },
         {
-            "id": 201005,
+            "id": "201005",
             "description": "Player(iOS): Metal & OpenGLES APIs",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -67,7 +67,7 @@
             "solution": "To reduce build size, remove OpenGLES graphics API if the minimum spec target device supports Metal."
         },
         {
-            "id": 201006,
+            "id": "201006",
             "description": "Player (iOS): Metal API",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -78,7 +78,7 @@
             "solution": "Enable Metal graphics API for better CPU Performance."
         },
         {
-            "id": 201007,
+            "id": "201007",
             "description": "Player: Prebake Collision Meshes",
             "type": "UnityEditor.PlayerSettings",
             "method": "bakeCollisionMeshes",
@@ -88,7 +88,7 @@
             "solution": "If you are using physics in your application, consider enabling this option. Prebaked collision meshes can result in an increase in build times and sizes, but reduce loading/initialization times in your application, because serializing prebaked meshes is faster than baking them at runtime."
         },
         {
-            "id": 201008,
+            "id": "201008",
             "description": "Player: Optimize Mesh Data",
             "type": "UnityEditor.PlayerSettings",
             "method": "stripUnusedMeshComponents",
@@ -98,7 +98,7 @@
             "solution": "Consider enabling it. This option strips out vertex channels on meshes which are not used by the materials which are applied to them. This can reduce the file size of your meshes and the time to load them, and increase GPU rendering performance. It can, however, cause problems if mesh materials are changed at runtime, since the new materials might rely on vertex channels which have been removed, and it may contribute to longer build times."
         },
         {
-            "id": 201009,
+            "id": "201009",
             "description": "Player: Engine Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "stripEngineCode",
@@ -109,7 +109,7 @@
             "solution": "Enable <b>stripEngineCode</b> in <b>Project Settings ➔ Player ➔ Other Settings</b>"
         },
         {
-            "id": 201010,
+            "id": "201010",
             "description": "Player (WebGL): Data Caching",
             "type": "UnityEditor.PlayerSettings+WebGL",
             "method": "dataCaching",
@@ -120,7 +120,7 @@
             "solution": "Enable <b>dataCaching</b> to cache build files in Browser cache"
         },
         {
-            "id": 201011,
+            "id": "201011",
             "description": "Player (WebGL): Linker Target",
             "type": "UnityEditor.PlayerSettings+WebGL",
             "method": "linkerTarget",
@@ -132,7 +132,7 @@
             "minimumVersion": "2018.1"
         },
         {
-            "id": 201012,
+            "id": "201012",
             "description": "Physics: Auto Sync Transforms",
             "type": "UnityEngine.Physics",
             "method": "autoSyncTransforms",
@@ -142,7 +142,7 @@
             "solution": "Consider disabling <b>Auto Sync Transforms</b> and testing your game to identify any areas where physics behavior is affected by the change. If there are areas of the game where more frequent synchronization is required to maintain the desired behaviour, this can be enforced by calling Physics.SyncTransforms() directly."
         },
         {
-            "id": 201013,
+            "id": "201013",
             "description": "Physics: Layer Collision Matrix",
             "type": "UnityEngine.Physics",
             "method": "GetIgnoreLayerCollision",
@@ -152,7 +152,7 @@
             "solution": "Un-tick all of the boxes except the ones that represent collisions that should be considered by the physics system."
         },
         {
-            "id": 201014,
+            "id": "201014",
             "description": "Physics2D: Auto Sync Transforms",
             "type": "UnityEngine.Physics2D",
             "method": "autoSyncTransforms",
@@ -162,7 +162,7 @@
             "solution": "Consider disabling <b>Auto Sync Transforms</b> and testing your game to identify any areas where physics behavior is affected by the change. If there are areas of the game where more frequent synchronization is required to maintain the desired behaviour, this can be enforced by calling Physics2D.SyncTransforms() directly."
         },
         {
-            "id": 201015,
+            "id": "201015",
             "description": "Physics2D: Layer Collision Matrix",
             "type": "UnityEngine.Physics2D",
             "method": "GetIgnoreLayerCollision",
@@ -172,7 +172,7 @@
             "solution": "Un-tick all of the boxes except the ones that represent collisions that should be considered by the 2D physics system."
         },
         {
-            "id": 201016,
+            "id": "201016",
             "description": "Time: Fixed Timestep",
             "type": "UnityEngine.Time",
             "method": "fixedDeltaTime",
@@ -182,7 +182,7 @@
             "solution": "We recommend setting Fixed Timestep to 0.04 when running at 30 FPS, in order to call the fixed updates at 25 Hz. The reason for having the fixed update be slightly less than the target frame rate is to avoid the “spiral of death”, in which if one frame takes longer than 33.3ms, FixedUpdate() happens multiple times on the next frame to catch up, pushing that frame time over as well, and permanently locking the game into a state where it cannot reach the desired frame rate because FixedUpdate() is constantly trying to catch up."
         },
         {
-            "id": 201017,
+            "id": "201017",
             "description": "Time: Maximum Allowed Timestep",
             "type": "UnityEngine.Time",
             "method": "maximumDeltaTime",
@@ -192,7 +192,7 @@
             "solution": "Consider reducing <b>Maximum Allowed Timestep</b> to a time that can be comfortably accommodated within your project's target frame rate."
         },
         {
-            "id": 201018,
+            "id": "201018",
             "description": "Quality: Quality Levels",
             "type": "UnityEngine.QualitySettings",
             "method": "GetQualityLevel",
@@ -202,7 +202,7 @@
             "solution": "Check the quality setting for each platform the project supports in the grid - it's the level with the green tick. Remove quality levels you are not using, to make the Quality Settings simpler to see and edit. Adjust the setting for each platform if necessary, then select the appropriate levels to examine their settings in the panel below."
         },
         {
-            "id": 201019,
+            "id": "201019",
             "description": "Quality: Texture Quality",
             "type": "UnityEngine.QualitySettings",
             "method": "masterTextureLimit",
@@ -212,7 +212,7 @@
             "solution": "For devices which must use lower-resolution versions of textures, consider creating these lower resolution textures separately, and choosing the appropriate content to load at runtime using AssetBundle variants."
         },
         {
-            "id": 201020,
+            "id": "201020",
             "description": "Quality: Async Upload Time Slice",
             "type": "UnityEngine.QualitySettings",
             "method": "asyncUploadTimeSlice",
@@ -222,7 +222,7 @@
             "solution": "If the project encounters long loading times when loading large amount of texture and/or mesh data, experiment with increasing this value to see if it allows content to be uploaded to the GPU more quickly."
         },
         {
-            "id": 201021,
+            "id": "201021",
             "description": "Quality: Async Upload Buffer Size",
             "type": "UnityEngine.QualitySettings",
             "method": "asyncUploadBufferSize",
@@ -232,7 +232,7 @@
             "solution": "If the project encounters long loading times when loading large amount of texture and/or mesh data, experiment with increasing this value to see if it allows content to be uploaded to the GPU more quickly. This is most likely to help if you are loading large textures. Note that this setting controls a buffer size in megabytes, so exercise caution if memory is limited in your application."
         },
         {
-            "id": 201022,
+            "id": "201022",
             "description": "Graphics: Shader Quality",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -242,7 +242,7 @@
             "solution": "Unless you support devices with a very wide range of capabilities for a particular platform, consider editing the platform in Graphics Settings to use the same shader quality setting across all Graphics Tiers."
         },
         {
-            "id": 201023,
+            "id": "201023",
             "description": "Graphics: Forward Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -252,7 +252,7 @@
             "solution": "This rendering path is suitable for games with simple rendering and lighting requirements - for instance, 2D games, or games which mainly use baked lighting. If the project makes use of a more than a few dynamic lights, consider experimenting with changing <b>Rendering Path</b> to Deferred to see whether doing so improves GPU rendering times."
         },
         {
-            "id": 201024,
+            "id": "201024",
             "description": "Graphics: Deferred Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -262,7 +262,7 @@
             "solution": "This rendering path is suitable for games with more complex rendering requirements - for instance, games that make uses of dynamic lighting or certain types of fullscreen post-processing effects. If the project doesn't make use of such rendering techniques, consider experimenting with changing <b>Rendering Path</b> to Forward to see whether doing so improves GPU rendering times."
         },
         {
-            "id": 201025,
+            "id": "201025",
             "description": "Player (Android): Managed Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetManagedStrippingLevel",
@@ -273,7 +273,7 @@
             "solution": "Set managed stripping level to Medium or High."
         },
         {
-            "id": 201026,
+            "id": "201026",
             "description": "Player (iOS): Managed Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetManagedStrippingLevel",

--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -1,7 +1,7 @@
 {
     "Items": [
         {
-            "id": "201000",
+            "id": "SD0000",
             "description": "Player: Metal API Validation",
             "type": "UnityEditor.PlayerSettings",
             "method": "enableMetalAPIValidation",
@@ -13,7 +13,7 @@
             "minimumVersion": "2018.1"
         },
         {
-            "id": "201001",
+            "id": "SD0001",
             "description": "Player: Graphics Jobs (Experimental)",
             "type": "UnityEditor.PlayerSettings",
             "method": "graphicsJobs",
@@ -23,7 +23,7 @@
             "solution": "Try enabling it and testing your application. This option spreads the task of building the render command buffer every frame across as many CPU cores as possible, rather than performing all the work in the render thread which is often a bottleneck. Note: This feature is experimental. It may not deliver a performance improvement for your project, and may introduce new crashes. Test accordingly."
         },
         {
-            "id": "201002",
+            "id": "SD0002",
             "description": "Player (iOS): Accelerometer",
             "type": "UnityEditor.PlayerSettings",
             "method": "accelerometerFrequency",
@@ -34,7 +34,7 @@
             "solution": "Consider setting <b>Accelerometer Frequency</b> to Disabled if your application doesn't make use of the device's accelerometer. Disabling this option will save a tiny amount of CPU processing time."
         },
         {
-            "id": "201003",
+            "id": "SD0003",
             "description": "Player (iOS): Building multiple architectures",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetArchitecture",
@@ -45,7 +45,7 @@
             "solution": "If your application isn't intended to support 32-bit iOS devices, change <b>Architecture</b> to ARM64."
         },
         {
-            "id": "201004",
+            "id": "SD0004",
             "description": "Player (Android): Building multiple architectures",
             "type": "UnityEditor.PlayerSettings",
             "method": "Android.targetArchitectures",
@@ -56,7 +56,7 @@
             "solution": "If your application isn't intended to support 32-bit Android devices, disable the <b>ARMv7</b> option."
         },
         {
-            "id": "201005",
+            "id": "SD0005",
             "description": "Player(iOS): Metal & OpenGLES APIs",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -67,7 +67,7 @@
             "solution": "To reduce build size, remove OpenGLES graphics API if the minimum spec target device supports Metal."
         },
         {
-            "id": "201006",
+            "id": "SD0006",
             "description": "Player (iOS): Metal API",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -78,7 +78,7 @@
             "solution": "Enable Metal graphics API for better CPU Performance."
         },
         {
-            "id": "201007",
+            "id": "SD0007",
             "description": "Player: Prebake Collision Meshes",
             "type": "UnityEditor.PlayerSettings",
             "method": "bakeCollisionMeshes",
@@ -88,7 +88,7 @@
             "solution": "If you are using physics in your application, consider enabling this option. Prebaked collision meshes can result in an increase in build times and sizes, but reduce loading/initialization times in your application, because serializing prebaked meshes is faster than baking them at runtime."
         },
         {
-            "id": "201008",
+            "id": "SD0008",
             "description": "Player: Optimize Mesh Data",
             "type": "UnityEditor.PlayerSettings",
             "method": "stripUnusedMeshComponents",
@@ -98,7 +98,7 @@
             "solution": "Consider enabling it. This option strips out vertex channels on meshes which are not used by the materials which are applied to them. This can reduce the file size of your meshes and the time to load them, and increase GPU rendering performance. It can, however, cause problems if mesh materials are changed at runtime, since the new materials might rely on vertex channels which have been removed, and it may contribute to longer build times."
         },
         {
-            "id": "201009",
+            "id": "SD0009",
             "description": "Player: Engine Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "stripEngineCode",
@@ -109,7 +109,7 @@
             "solution": "Enable <b>stripEngineCode</b> in <b>Project Settings ➔ Player ➔ Other Settings</b>"
         },
         {
-            "id": "201010",
+            "id": "SD0010",
             "description": "Player (WebGL): Data Caching",
             "type": "UnityEditor.PlayerSettings+WebGL",
             "method": "dataCaching",
@@ -120,7 +120,7 @@
             "solution": "Enable <b>dataCaching</b> to cache build files in Browser cache"
         },
         {
-            "id": "201011",
+            "id": "SD0011",
             "description": "Player (WebGL): Linker Target",
             "type": "UnityEditor.PlayerSettings+WebGL",
             "method": "linkerTarget",
@@ -132,7 +132,7 @@
             "minimumVersion": "2018.1"
         },
         {
-            "id": "201012",
+            "id": "SD0012",
             "description": "Physics: Auto Sync Transforms",
             "type": "UnityEngine.Physics",
             "method": "autoSyncTransforms",
@@ -142,7 +142,7 @@
             "solution": "Consider disabling <b>Auto Sync Transforms</b> and testing your game to identify any areas where physics behavior is affected by the change. If there are areas of the game where more frequent synchronization is required to maintain the desired behaviour, this can be enforced by calling Physics.SyncTransforms() directly."
         },
         {
-            "id": "201013",
+            "id": "SD0013",
             "description": "Physics: Layer Collision Matrix",
             "type": "UnityEngine.Physics",
             "method": "GetIgnoreLayerCollision",
@@ -152,7 +152,7 @@
             "solution": "Un-tick all of the boxes except the ones that represent collisions that should be considered by the physics system."
         },
         {
-            "id": "201014",
+            "id": "SD0014",
             "description": "Physics2D: Auto Sync Transforms",
             "type": "UnityEngine.Physics2D",
             "method": "autoSyncTransforms",
@@ -162,7 +162,7 @@
             "solution": "Consider disabling <b>Auto Sync Transforms</b> and testing your game to identify any areas where physics behavior is affected by the change. If there are areas of the game where more frequent synchronization is required to maintain the desired behaviour, this can be enforced by calling Physics2D.SyncTransforms() directly."
         },
         {
-            "id": "201015",
+            "id": "SD0015",
             "description": "Physics2D: Layer Collision Matrix",
             "type": "UnityEngine.Physics2D",
             "method": "GetIgnoreLayerCollision",
@@ -172,7 +172,7 @@
             "solution": "Un-tick all of the boxes except the ones that represent collisions that should be considered by the 2D physics system."
         },
         {
-            "id": "201016",
+            "id": "SD0016",
             "description": "Time: Fixed Timestep",
             "type": "UnityEngine.Time",
             "method": "fixedDeltaTime",
@@ -182,7 +182,7 @@
             "solution": "We recommend setting Fixed Timestep to 0.04 when running at 30 FPS, in order to call the fixed updates at 25 Hz. The reason for having the fixed update be slightly less than the target frame rate is to avoid the “spiral of death”, in which if one frame takes longer than 33.3ms, FixedUpdate() happens multiple times on the next frame to catch up, pushing that frame time over as well, and permanently locking the game into a state where it cannot reach the desired frame rate because FixedUpdate() is constantly trying to catch up."
         },
         {
-            "id": "201017",
+            "id": "SD0017",
             "description": "Time: Maximum Allowed Timestep",
             "type": "UnityEngine.Time",
             "method": "maximumDeltaTime",
@@ -192,7 +192,7 @@
             "solution": "Consider reducing <b>Maximum Allowed Timestep</b> to a time that can be comfortably accommodated within your project's target frame rate."
         },
         {
-            "id": "201018",
+            "id": "SD0018",
             "description": "Quality: Quality Levels",
             "type": "UnityEngine.QualitySettings",
             "method": "GetQualityLevel",
@@ -202,7 +202,7 @@
             "solution": "Check the quality setting for each platform the project supports in the grid - it's the level with the green tick. Remove quality levels you are not using, to make the Quality Settings simpler to see and edit. Adjust the setting for each platform if necessary, then select the appropriate levels to examine their settings in the panel below."
         },
         {
-            "id": "201019",
+            "id": "SD0019",
             "description": "Quality: Texture Quality",
             "type": "UnityEngine.QualitySettings",
             "method": "masterTextureLimit",
@@ -212,7 +212,7 @@
             "solution": "For devices which must use lower-resolution versions of textures, consider creating these lower resolution textures separately, and choosing the appropriate content to load at runtime using AssetBundle variants."
         },
         {
-            "id": "201020",
+            "id": "SD0020",
             "description": "Quality: Async Upload Time Slice",
             "type": "UnityEngine.QualitySettings",
             "method": "asyncUploadTimeSlice",
@@ -222,7 +222,7 @@
             "solution": "If the project encounters long loading times when loading large amount of texture and/or mesh data, experiment with increasing this value to see if it allows content to be uploaded to the GPU more quickly."
         },
         {
-            "id": "201021",
+            "id": "SD0021",
             "description": "Quality: Async Upload Buffer Size",
             "type": "UnityEngine.QualitySettings",
             "method": "asyncUploadBufferSize",
@@ -232,7 +232,7 @@
             "solution": "If the project encounters long loading times when loading large amount of texture and/or mesh data, experiment with increasing this value to see if it allows content to be uploaded to the GPU more quickly. This is most likely to help if you are loading large textures. Note that this setting controls a buffer size in megabytes, so exercise caution if memory is limited in your application."
         },
         {
-            "id": "201022",
+            "id": "SD0022",
             "description": "Graphics: Shader Quality",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -242,7 +242,7 @@
             "solution": "Unless you support devices with a very wide range of capabilities for a particular platform, consider editing the platform in Graphics Settings to use the same shader quality setting across all Graphics Tiers."
         },
         {
-            "id": "201023",
+            "id": "SD0023",
             "description": "Graphics: Forward Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -252,7 +252,7 @@
             "solution": "This rendering path is suitable for games with simple rendering and lighting requirements - for instance, 2D games, or games which mainly use baked lighting. If the project makes use of a more than a few dynamic lights, consider experimenting with changing <b>Rendering Path</b> to Deferred to see whether doing so improves GPU rendering times."
         },
         {
-            "id": "201024",
+            "id": "SD0024",
             "description": "Graphics: Deferred Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
             "method": "GetTierSettings",
@@ -262,7 +262,7 @@
             "solution": "This rendering path is suitable for games with more complex rendering requirements - for instance, games that make uses of dynamic lighting or certain types of fullscreen post-processing effects. If the project doesn't make use of such rendering techniques, consider experimenting with changing <b>Rendering Path</b> to Forward to see whether doing so improves GPU rendering times."
         },
         {
-            "id": "201025",
+            "id": "SD0025",
             "description": "Player (Android): Managed Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetManagedStrippingLevel",
@@ -273,7 +273,7 @@
             "solution": "Set managed stripping level to Medium or High."
         },
         {
-            "id": "201026",
+            "id": "SD0026",
             "description": "Player (iOS): Managed Code Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetManagedStrippingLevel",
@@ -284,7 +284,7 @@
             "solution": "Set managed stripping level to Medium or High."
         },
         {
-            "id": 201027,
+            "id": "SD0027",
             "description": "Player: Mipmap Stripping",
             "type": "UnityEditor.PlayerSettings",
             "method": "mipStripping",
@@ -295,7 +295,7 @@
             "minimumVersion": "2020.2"
         },
         {
-            "id": 201028,
+            "id": "SD0028",
             "description": "Physics: Reuse Collision Callbacks",
             "type": "UnityEngine.Physics",
             "method": "reuseCollisionCallbacks",
@@ -306,7 +306,7 @@
             "minimumVersion": "2018.3"
         },
         {
-            "id": 201029,
+            "id": "SD0029",
             "description": "Player: Splash Screen",
             "type": "UnityEditor.PlayerSettings+SplashScreen",
             "method": "show",
@@ -316,7 +316,7 @@
             "solution": "Disable the Splash Screen option in <b>Project Settings ➔ Player ➔ Splash Image ➔ Show Splash Screen</b>."
         },
         {
-            "id": 201030,
+            "id": "SD0030",
             "description": "Player (Android): Optimized Frame Pacing",
             "type": "UnityEditor.PlayerSettings+Android",
             "method": "optimizedFramePacing",
@@ -328,7 +328,7 @@
             "minimumVersion": "2019.2"
         },
         {
-            "id": 201031,
+            "id": "SD0031",
             "description": "Player (Android): Vulkan API",
             "type": "UnityEditor.PlayerSettings",
             "method": "GetGraphicsAPIs",
@@ -337,6 +337,6 @@
             "platforms": ["Android"],
             "problem": "In the Android Player Settings, Vulkan graphics API is not enabled.",
             "solution": "Enable Vulkan graphics API for better CPU Performance."
-        }     
+        }
     ]
 }

--- a/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_ObjectAllocationDescriptor = new ProblemDescriptor
             (
-            "102002",
+            "CD2002",
             "Object Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
@@ -22,7 +22,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         static readonly ProblemDescriptor k_ClosureAllocationDescriptor = new ProblemDescriptor
             (
-            "102003",
+            "CD2003",
             "Closure Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
@@ -35,7 +35,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         static readonly ProblemDescriptor k_ArrayAllocationDescriptor = new ProblemDescriptor
             (
-            "102004",
+            "CD2004",
             "Array Allocation",
             Area.Memory,
             "An array is allocated in managed memory",

--- a/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_ObjectAllocationDescriptor = new ProblemDescriptor
             (
-            "CD2002",
+            "PAC2002",
             "Object Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
@@ -22,7 +22,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         static readonly ProblemDescriptor k_ClosureAllocationDescriptor = new ProblemDescriptor
             (
-            "CD2003",
+            "PAC2003",
             "Closure Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
@@ -35,7 +35,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         static readonly ProblemDescriptor k_ArrayAllocationDescriptor = new ProblemDescriptor
             (
-            "CD2004",
+            "PAC2004",
             "Array Allocation",
             Area.Memory,
             "An array is allocated in managed memory",

--- a/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/AllocationAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_ObjectAllocationDescriptor = new ProblemDescriptor
             (
-            102002,
+            "102002",
             "Object Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
@@ -22,7 +22,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         static readonly ProblemDescriptor k_ClosureAllocationDescriptor = new ProblemDescriptor
             (
-            102003,
+            "102003",
             "Closure Allocation",
             Area.Memory,
             "An object is allocated in managed memory",
@@ -35,7 +35,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 
         static readonly ProblemDescriptor k_ArrayAllocationDescriptor = new ProblemDescriptor
             (
-            102004,
+            "102004",
             "Array Allocation",
             Area.Memory,
             "An array is allocated in managed memory",

--- a/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor
             (
-            "102000",
+            "CD2000",
             "Boxing Allocation",
             Area.Memory,
             "Boxing happens where a value type, such as an integer, is converted into an object of reference type. This causes an allocation on the heap, which might increase the size of the managed heap and the frequency of Garbage Collection.",

--- a/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor
             (
-            102000,
+            "102000",
             "Boxing Allocation",
             Area.Memory,
             "Boxing happens where a value type, such as an integer, is converted into an object of reference type. This causes an allocation on the heap, which might increase the size of the managed heap and the frequency of Garbage Collection.",

--- a/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/BoxingAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor
             (
-            "CD2000",
+            "PAC2000",
             "Boxing Allocation",
             Area.Memory,
             "Boxing happens where a value type, such as an integer, is converted into an object of reference type. This causes an allocation on the heap, which might increase the size of the managed heap and the frequency of Garbage Collection.",

--- a/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor
             (
-            "CD2001",
+            "PAC2001",
             "Empty MonoBehaviour Method",
             Area.CPU,
             "Any empty MonoBehaviour magic method will be included in the build and executed anyway.",

--- a/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor
             (
-            102001,
+            "102001",
             "Empty MonoBehaviour Method",
             Area.CPU,
             "Any empty MonoBehaviour magic method will be included in the build and executed anyway.",

--- a/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/EmptyMethodAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor
             (
-            "102001",
+            "CD2001",
             "Empty MonoBehaviour Method",
             Area.CPU,
             "Any empty MonoBehaviour magic method will be included in the build and executed anyway.",

--- a/Editor/InstructionAnalyzers/GenericTypeInstantiationAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/GenericTypeInstantiationAnalyzer.cs
@@ -34,7 +34,7 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
                 var genericTypeName = typeDefinition.FullName;
                 if (!m_GenericDescriptors.ContainsKey(genericTypeName))
                 {
-                    var desc = new ProblemDescriptor(k_FirstDescriptorId + m_GenericDescriptors.Count,
+                    var desc = new ProblemDescriptor((k_FirstDescriptorId + m_GenericDescriptors.Count).ToString(),
                         typeDefinition.FullName, Area.BuildSize)
                     {
                         messageFormat = "'{0}' generic instance"

--- a/Editor/ProblemDescriptor.cs
+++ b/Editor/ProblemDescriptor.cs
@@ -46,7 +46,7 @@ namespace Unity.ProjectAuditor.Editor
     public sealed class ProblemDescriptor : IEquatable<ProblemDescriptor>
     {
         // An unique identifier for the diagnostic
-        public int id;
+        public string id;
         public string description;
         public string messageFormat;
 
@@ -68,7 +68,7 @@ namespace Unity.ProjectAuditor.Editor
         public string method;
         public string value;
 
-        internal ProblemDescriptor(int id, string description, string[] areas, string problem = null, string solution = null)
+        internal ProblemDescriptor(string id, string description, string[] areas, string problem = null, string solution = null)
         {
             this.id = id;
             this.description = description;
@@ -82,12 +82,12 @@ namespace Unity.ProjectAuditor.Editor
             critical = false;
         }
 
-        public ProblemDescriptor(int id, string description, Area area, string problem = null, string solution = null)
+        public ProblemDescriptor(string id, string description, Area area, string problem = null, string solution = null)
             : this(id, description, new[] {area.ToString()}, problem, solution)
         {
         }
 
-        public ProblemDescriptor(int id, string description, Area[] areas, string problem = null, string solution = null)
+        public ProblemDescriptor(string id, string description, Area[] areas, string problem = null, string solution = null)
             : this(id, description, areas.Select(a => a.ToString()).ToArray(), problem, solution)
         {
         }
@@ -108,7 +108,7 @@ namespace Unity.ProjectAuditor.Editor
 
         public override int GetHashCode()
         {
-            return id;
+            return id.GetHashCode();
         }
     }
 }

--- a/Editor/ProjectAuditorConfig.cs
+++ b/Editor/ProjectAuditorConfig.cs
@@ -31,7 +31,6 @@ namespace Unity.ProjectAuditor.Editor
         /// </summary>
         public bool UseRoslynAnalyzers;
 
-
         /// <summary>
         /// If enabled, any issue reported by ProjectAuditor will cause the build to fail.
         /// </summary>
@@ -42,7 +41,8 @@ namespace Unity.ProjectAuditor.Editor
         /// </summary>
         public bool SaveBuildReports;
 
-        [SerializeField] List<Rule> m_Rules = new List<Rule>();
+        [SerializeField]
+        List<Rule> m_Rules = new List<Rule>();
 
         public int NumRules
         {

--- a/Editor/Rule.cs
+++ b/Editor/Rule.cs
@@ -18,7 +18,7 @@ namespace Unity.ProjectAuditor.Editor
         public Severity severity;
         public string filter;
 
-        public int id;
+        public string id;
 
         public bool Equals(Rule other)
         {

--- a/Editor/SettingsAnalysis/HDRenderPipelineAnalyzer.cs
+++ b/Editor/SettingsAnalysis/HDRenderPipelineAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
     class HDRenderPipelineAnalyzer : ISettingsAnalyzer
     {
         static readonly ProblemDescriptor k_AssetLitShaderModeBothOrMixed = new ProblemDescriptor(
-            202001,
+            "SD1001",
             "HDRP: Render Pipeline Assets use both 'Lit Shader Mode' Forward and Deferred",
             new[] { Area.BuildSize, Area.BuildTime },
             "If HDRP 'Lit Shader Mode' is set to Both (or a mix of Forward and Deferred), shaders will be built for both Forward and Deferred rendering. This increases build time and size.",
@@ -22,7 +22,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
         );
 
         static readonly ProblemDescriptor k_CameraLitShaderModeBothOrMixed = new ProblemDescriptor(
-            202002,
+            "SD1002",
             "HDRP: Cameras mix usage of 'Lit Shader Mode' Forward and Deferred",
             new[] { Area.BuildSize, Area.BuildTime },
             "If Cameras use both 'Lit Shader Mode' Forward and Deferred, shaders will be built for both Forward and Deferred rendering. This increases build time and size.",

--- a/Editor/SettingsAnalysis/HDRenderPipelineAnalyzer.cs
+++ b/Editor/SettingsAnalysis/HDRenderPipelineAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
     class HDRenderPipelineAnalyzer : ISettingsAnalyzer
     {
         static readonly ProblemDescriptor k_AssetLitShaderModeBothOrMixed = new ProblemDescriptor(
-            "SD1001",
+            "PAS1001",
             "HDRP: Render Pipeline Assets use both 'Lit Shader Mode' Forward and Deferred",
             new[] { Area.BuildSize, Area.BuildTime },
             "If HDRP 'Lit Shader Mode' is set to Both (or a mix of Forward and Deferred), shaders will be built for both Forward and Deferred rendering. This increases build time and size.",
@@ -22,7 +22,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
         );
 
         static readonly ProblemDescriptor k_CameraLitShaderModeBothOrMixed = new ProblemDescriptor(
-            "SD1002",
+            "PAS1002",
             "HDRP: Cameras mix usage of 'Lit Shader Mode' Forward and Deferred",
             new[] { Area.BuildSize, Area.BuildTime },
             "If Cameras use both 'Lit Shader Mode' Forward and Deferred, shaders will be built for both Forward and Deferred rendering. This increases build time and size.",

--- a/Editor/SettingsAnalysis/HybridRenderingAnalyzer.cs
+++ b/Editor/SettingsAnalysis/HybridRenderingAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
     class HybridRenderingAnalyzer : ISettingsAnalyzer
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor(
-            "SD1000",
+            "PAS1000",
             "Player Settings: Static batching is enabled",
             Area.CPU,
             "Static batching is enabled and the package com.unity.rendering.hybrid is installed. Static batching is incompatible with the batching techniques used in the Hybrid Renderer and Scriptable Render Pipeline, and will result in poor rendering performance and excessive memory use.",

--- a/Editor/SettingsAnalysis/HybridRenderingAnalyzer.cs
+++ b/Editor/SettingsAnalysis/HybridRenderingAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
     class HybridRenderingAnalyzer : ISettingsAnalyzer
     {
         static readonly ProblemDescriptor k_Descriptor = new ProblemDescriptor(
-            202000,
+            "SD1000",
             "Player Settings: Static batching is enabled",
             Area.CPU,
             "Static batching is enabled and the package com.unity.rendering.hybrid is installed. Static batching is incompatible with the batching techniques used in the Hybrid Renderer and Scriptable Render Pipeline, and will result in poor rendering performance and excessive memory use.",

--- a/Editor/UI/ProjectAuditorAnalytics.cs
+++ b/Editor/UI/ProjectAuditorAnalytics.cs
@@ -121,7 +121,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         [Serializable]
         public struct IssueStats
         {
-            public int id;
+            public string id;
             public int numOccurrences;
             public int numHotPathOccurrences;
         }
@@ -227,7 +227,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         static IssueStats[] CollectSelectionStats(IssueTableItem[] selectedItems)
         {
-            var selectionsDict = new Dictionary<int, IssueStats>();
+            var selectionsDict = new Dictionary<string, IssueStats>();
             var selectedChildren = selectedItems.Where(item => item.parent != null);
 
             foreach (var childItem in selectedChildren)
@@ -254,7 +254,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         static IssueStats[] GetScriptIssuesSummary(ProjectReport projectReport)
         {
-            var statsDict = new Dictionary<int, IssueStats>();
+            var statsDict = new Dictionary<string, IssueStats>();
 
             var scriptIssues = projectReport.GetIssues(IssueCategory.Code);
             var numScriptIssues = scriptIssues.Count;

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -88,7 +88,7 @@ namespace Unity.ProjectAuditor.Editor
         public bool critical;
         public string customevaluator;
         public string description;
-        public int id;
+        public string id;
         public string maximumVersion;
         public string messageFormat;
         public string method;
@@ -99,8 +99,8 @@ namespace Unity.ProjectAuditor.Editor
         public string solution;
         public string type;
         public string value;
-        public ProblemDescriptor(int id, string description, Unity.ProjectAuditor.Editor.Area area, string problem = default(string), string solution = default(string)) {}
-        public ProblemDescriptor(int id, string description, Unity.ProjectAuditor.Editor.Area[] areas, string problem = default(string), string solution = default(string)) {}
+        public ProblemDescriptor(string id, string description, Unity.ProjectAuditor.Editor.Area area, string problem = default(string), string solution = default(string)) {}
+        public ProblemDescriptor(string id, string description, Unity.ProjectAuditor.Editor.Area[] areas, string problem = default(string), string solution = default(string)) {}
         public virtual bool Equals(object obj);
         public virtual bool Equals(Unity.ProjectAuditor.Editor.ProblemDescriptor other);
         public virtual int GetHashCode();
@@ -269,7 +269,7 @@ namespace Unity.ProjectAuditor.Editor
     public class Rule : System.IEquatable<Unity.ProjectAuditor.Editor.Rule>
     {
         public string filter;
-        public int id;
+        public string id;
         public Unity.ProjectAuditor.Editor.Rule.Severity severity;
         public Rule() {}
         public virtual bool Equals(object obj);

--- a/Tests/Editor/BoxingIssueTests.cs
+++ b/Tests/Editor/BoxingIssueTests.cs
@@ -47,7 +47,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingInt.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingInt.descriptor.severity);
-            Assert.AreEqual("102000", boxingInt.descriptor.id);
+            Assert.AreEqual("CD0003", boxingInt.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingInt.descriptor.description));
@@ -74,7 +74,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingFloat.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingFloat.descriptor.severity);
-            Assert.AreEqual("102000", boxingFloat.descriptor.id);
+            Assert.AreEqual("CD0003", boxingFloat.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingFloat.descriptor.description));

--- a/Tests/Editor/BoxingIssueTests.cs
+++ b/Tests/Editor/BoxingIssueTests.cs
@@ -47,7 +47,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingInt.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingInt.descriptor.severity);
-            Assert.AreEqual(102000, boxingInt.descriptor.id);
+            Assert.AreEqual("102000", boxingInt.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingInt.descriptor.description));
@@ -74,7 +74,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingFloat.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingFloat.descriptor.severity);
-            Assert.AreEqual(102000, boxingFloat.descriptor.id);
+            Assert.AreEqual("102000", boxingFloat.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingFloat.descriptor.description));

--- a/Tests/Editor/BoxingIssueTests.cs
+++ b/Tests/Editor/BoxingIssueTests.cs
@@ -47,7 +47,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingInt.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingInt.descriptor.severity);
-            Assert.AreEqual("CD0003", boxingInt.descriptor.id);
+            Assert.AreEqual("CD2000", boxingInt.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingInt.descriptor.description));
@@ -74,7 +74,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingFloat.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingFloat.descriptor.severity);
-            Assert.AreEqual("CD0003", boxingFloat.descriptor.id);
+            Assert.AreEqual("CD2000", boxingFloat.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingFloat.descriptor.description));

--- a/Tests/Editor/BoxingIssueTests.cs
+++ b/Tests/Editor/BoxingIssueTests.cs
@@ -47,7 +47,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingInt.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingInt.descriptor.severity);
-            Assert.AreEqual("CD2000", boxingInt.descriptor.id);
+            Assert.AreEqual("PAC2000", boxingInt.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingInt.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingInt.descriptor.description));
@@ -74,7 +74,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // check descriptor
             Assert.NotNull(boxingFloat.descriptor);
             Assert.AreEqual(Rule.Severity.Default, boxingFloat.descriptor.severity);
-            Assert.AreEqual("CD2000", boxingFloat.descriptor.id);
+            Assert.AreEqual("PAC2000", boxingFloat.descriptor.id);
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.type));
             Assert.True(string.IsNullOrEmpty(boxingFloat.descriptor.method));
             Assert.False(string.IsNullOrEmpty(boxingFloat.descriptor.description));

--- a/Tests/Editor/CodeAnalysisTests.cs
+++ b/Tests/Editor/CodeAnalysisTests.cs
@@ -285,7 +285,7 @@ class UxmlAttributeDescriptionPropertyUsage
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
             Assert.AreEqual(typeof(string), myIssue.descriptor.id.GetType());
-            Assert.AreEqual("CD0066", myIssue.descriptor.id);
+            Assert.AreEqual("PAC0066", myIssue.descriptor.id);
             Assert.AreEqual("UnityEngine.Camera", myIssue.descriptor.type);
             Assert.AreEqual("allCameras", myIssue.descriptor.method);
 

--- a/Tests/Editor/CodeAnalysisTests.cs
+++ b/Tests/Editor/CodeAnalysisTests.cs
@@ -284,7 +284,8 @@ class UxmlAttributeDescriptionPropertyUsage
             Assert.NotNull(myIssue.descriptor);
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
-            Assert.AreEqual(101066, myIssue.descriptor.id);
+            Assert.AreEqual(typeof(string), myIssue.descriptor.id.GetType());
+            Assert.AreEqual("101066", myIssue.descriptor.id);
             Assert.AreEqual("UnityEngine.Camera", myIssue.descriptor.type);
             Assert.AreEqual("allCameras", myIssue.descriptor.method);
 

--- a/Tests/Editor/CodeAnalysisTests.cs
+++ b/Tests/Editor/CodeAnalysisTests.cs
@@ -285,7 +285,7 @@ class UxmlAttributeDescriptionPropertyUsage
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
             Assert.AreEqual(typeof(string), myIssue.descriptor.id.GetType());
-            Assert.AreEqual("101066", myIssue.descriptor.id);
+            Assert.AreEqual("CD0066", myIssue.descriptor.id);
             Assert.AreEqual("UnityEngine.Camera", myIssue.descriptor.type);
             Assert.AreEqual("allCameras", myIssue.descriptor.method);
 

--- a/Tests/Editor/LinqIssueTests.cs
+++ b/Tests/Editor/LinqIssueTests.cs
@@ -41,7 +41,7 @@ class MyClass
             Assert.NotNull(myIssue.descriptor);
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
-            Assert.AreEqual(101049, myIssue.descriptor.id);
+            Assert.AreEqual("101049", myIssue.descriptor.id);
             Assert.AreEqual("System.Linq", myIssue.descriptor.type);
             Assert.AreEqual("*", myIssue.descriptor.method);
 

--- a/Tests/Editor/LinqIssueTests.cs
+++ b/Tests/Editor/LinqIssueTests.cs
@@ -41,7 +41,7 @@ class MyClass
             Assert.NotNull(myIssue.descriptor);
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
-            Assert.AreEqual("CD1000", myIssue.descriptor.id);
+            Assert.AreEqual("PAC1000", myIssue.descriptor.id);
             Assert.AreEqual("System.Linq", myIssue.descriptor.type);
             Assert.AreEqual("*", myIssue.descriptor.method);
 

--- a/Tests/Editor/LinqIssueTests.cs
+++ b/Tests/Editor/LinqIssueTests.cs
@@ -41,7 +41,7 @@ class MyClass
             Assert.NotNull(myIssue.descriptor);
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
-            Assert.AreEqual("CD0000", myIssue.descriptor.id);
+            Assert.AreEqual("CD1000", myIssue.descriptor.id);
             Assert.AreEqual("System.Linq", myIssue.descriptor.type);
             Assert.AreEqual("*", myIssue.descriptor.method);
 

--- a/Tests/Editor/LinqIssueTests.cs
+++ b/Tests/Editor/LinqIssueTests.cs
@@ -41,7 +41,7 @@ class MyClass
             Assert.NotNull(myIssue.descriptor);
 
             Assert.AreEqual(Rule.Severity.Default, myIssue.descriptor.severity);
-            Assert.AreEqual("101049", myIssue.descriptor.id);
+            Assert.AreEqual("CD0000", myIssue.descriptor.id);
             Assert.AreEqual("System.Linq", myIssue.descriptor.type);
             Assert.AreEqual("*", myIssue.descriptor.method);
 

--- a/Tests/Editor/ModuleTests.cs
+++ b/Tests/Editor/ModuleTests.cs
@@ -11,7 +11,7 @@ namespace Unity.ProjectAuditor.EditorTests
 {
     class CustomAuditor// : IAuditor
     {
-        readonly ProblemDescriptor m_Descriptor = new ProblemDescriptor(666, "This is a test descriptor", Area.CPU);
+        readonly ProblemDescriptor m_Descriptor = new ProblemDescriptor("666", "This is a test descriptor", Area.CPU);
 
         private readonly IssueLayout m_Layout = new IssueLayout
         {

--- a/Tests/Editor/ProblemDescriptorTests.cs
+++ b/Tests/Editor/ProblemDescriptorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
 using Unity.ProjectAuditor.Editor.Utils;
@@ -108,7 +109,6 @@ namespace Unity.ProjectAuditor.EditorTests
         }
 
         [Test]
-
         public void ProblemDescriptor_MultipleAreas_AreCorrect()
         {
             var desc = new ProblemDescriptor
@@ -178,10 +178,12 @@ namespace Unity.ProjectAuditor.EditorTests
         [TestCase("ProjectSettings")]
         public void ProblemDescriptor_Descriptors_AreCorrect(string jsonFilename)
         {
+            var regExp = new Regex("^[a-z]{3}[0-9]{4}", RegexOptions.IgnoreCase);
             var descriptors = ProblemDescriptorLoader.LoadFromJson(Editor.ProjectAuditor.DataPath, jsonFilename);
             foreach (var descriptor in descriptors)
             {
                 Assert.NotNull(descriptor.id);
+                Assert.True(regExp.IsMatch(descriptor.id), "Descriptor id format is not valid: " + descriptor.id);
                 Assert.NotNull(descriptor.areas);
             }
         }

--- a/Tests/Editor/ProblemDescriptorTests.cs
+++ b/Tests/Editor/ProblemDescriptorTests.cs
@@ -18,7 +18,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var a = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -26,7 +26,7 @@ namespace Unity.ProjectAuditor.EditorTests
                 );
             var b = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -47,14 +47,14 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var p = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
                 "do nothing"
                 );
 
-            Assert.True(p.GetHashCode() == p.id);
+            Assert.AreEqual(p.id.GetHashCode(), p.GetHashCode());
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -108,11 +108,12 @@ namespace Unity.ProjectAuditor.EditorTests
         }
 
         [Test]
+
         public void ProblemDescriptor_MultipleAreas_AreCorrect()
         {
             var desc = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 new[] {Area.CPU, Area.Memory},
                 "this is not actually a problem",
@@ -128,7 +129,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 new[] {Area.CPU}
                 );
@@ -141,7 +142,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 new[] {Area.CPU}
                 )
@@ -161,7 +162,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 new[] {Area.CPU}
                 )
@@ -180,7 +181,7 @@ namespace Unity.ProjectAuditor.EditorTests
             var descriptors = ProblemDescriptorLoader.LoadFromJson(Editor.ProjectAuditor.DataPath, jsonFilename);
             foreach (var descriptor in descriptors)
             {
-                Assert.Positive(descriptor.id);
+                Assert.NotNull(descriptor.id);
                 Assert.NotNull(descriptor.areas);
             }
         }

--- a/Tests/Editor/ProblemDescriptorTests.cs
+++ b/Tests/Editor/ProblemDescriptorTests.cs
@@ -18,7 +18,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var a = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -26,7 +26,7 @@ namespace Unity.ProjectAuditor.EditorTests
                 );
             var b = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -47,7 +47,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var p = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -62,7 +62,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",
@@ -103,7 +103,7 @@ namespace Unity.ProjectAuditor.EditorTests
             desc.minimumVersion = "1.1";
             desc.maximumVersion = "1.0";
             var result = ProblemDescriptorLoader.IsVersionCompatible(desc);
-            LogAssert.Expect(LogType.Error, "Descriptor (102001) minimumVersion (1.1) is greater than maximumVersion (1.0).");
+            LogAssert.Expect(LogType.Error, "Descriptor (TD2001) minimumVersion (1.1) is greater than maximumVersion (1.0).");
             Assert.False(result);
         }
 
@@ -113,7 +113,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 new[] {Area.CPU, Area.Memory},
                 "this is not actually a problem",
@@ -129,7 +129,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 new[] {Area.CPU}
                 );
@@ -142,7 +142,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 new[] {Area.CPU}
                 )
@@ -162,7 +162,7 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var desc = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 new[] {Area.CPU}
                 )

--- a/Tests/Editor/ProjectIssueTests.cs
+++ b/Tests/Editor/ProjectIssueTests.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.EditorTests
     {
         ProblemDescriptor s_Descriptor = new ProblemDescriptor
             (
-            "102001",
+            "TD2001",
             "test",
             Area.CPU,
             "this is not actually a problem",

--- a/Tests/Editor/ProjectIssueTests.cs
+++ b/Tests/Editor/ProjectIssueTests.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.EditorTests
     {
         ProblemDescriptor s_Descriptor = new ProblemDescriptor
             (
-            102001,
+            "102001",
             "test",
             Area.CPU,
             "this is not actually a problem",

--- a/Tests/Editor/ProjectReportTests.cs
+++ b/Tests/Editor/ProjectReportTests.cs
@@ -47,7 +47,7 @@ class MyClass : MonoBehaviour
             var projectReport = new ProjectReport();
             var p = new ProblemDescriptor
                 (
-                "102001",
+                "TD2001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",

--- a/Tests/Editor/ProjectReportTests.cs
+++ b/Tests/Editor/ProjectReportTests.cs
@@ -47,7 +47,7 @@ class MyClass : MonoBehaviour
             var projectReport = new ProjectReport();
             var p = new ProblemDescriptor
                 (
-                102001,
+                "102001",
                 "test",
                 Area.CPU,
                 "this is not actually a problem",

--- a/Tests/Editor/RuleTests.cs
+++ b/Tests/Editor/RuleTests.cs
@@ -39,7 +39,7 @@ namespace Unity.ProjectAuditor.EditorTests
             // add rule with a filter.
             m_SerializedConfig.AddRule(new Rule
             {
-                id = 0,
+                id = "someid",
                 severity = Rule.Severity.None
             });
 


### PR DESCRIPTION
**Problem**
descriptors IDs are numeric. This approach is not ideal because as it does not provide much information to the reader, IDs. In addition, it is not consistent with other diagnostics which use 2/3 letters and 4 digits.

**Solution**
This PR changes the ID format from _int_ to _string_ and assign IDs based on the module they were reported from.
- Code: prefix "PAC" (Project Auditor Code)
- Settings: prefix "SD" (Project Auditor Setting)

note that there are different ranges within both Code and Settings diagnostic IDs:
- `PAC0xxx`: for Unity API
- `PAC1xxx`: for System.*
- `PAC2xxx`: other IDs defined in code rather than in the json
- `PAS0xxx`: Unity settings
- `PAS1xxx`:  other settings IDs defined in code rather than in the json