### PR TITLE
Param array creation diagnostic

### DIFF
--- a/Tests/Editor/AllocationTests.cs
+++ b/Tests/Editor/AllocationTests.cs
@@ -69,14 +69,14 @@ class MultidimensionalArrayAllocation
             m_TempAssetParamsArrayAllocation = new TempAsset("ParamsArrayAllocation.cs", @"
 class ParamsArrayAllocation
 {
-    void DummyImpl(params object[] args)
+    void MethodWithParams(params object[] args)
     {
     }
 
     void Dummy(object C)
     {
         // implicit array allocation
-        DummyImpl(null, null);
+        MethodWithParams(null, null);
     }
 }
 ");
@@ -137,12 +137,15 @@ class ParamsArrayAllocation
         public void CodeAnalysis_NewParamsArray_IsReported()
         {
             var issues = AnalyzeAndFindAssetIssues(m_TempAssetParamsArrayAllocation);
-            Assert.AreEqual(1, issues.Count());
+            Assert.AreEqual(2, issues.Count());
 
-            var allocationIssue = issues.First();
+            Assert.AreEqual(IssueCategory.Code, issues[0].category);
+            Assert.AreEqual("PAC2004", issues[0].descriptor.id);
+            Assert.AreEqual("'Object' array allocation", issues[0].description);
 
-            Assert.AreEqual("'Object' array allocation", allocationIssue.description);
-            Assert.AreEqual(IssueCategory.Code, allocationIssue.category);
+            Assert.AreEqual(IssueCategory.Code, issues[1].category);
+            Assert.AreEqual("PAC2005", issues[1].descriptor.id);
+            Assert.AreEqual("Parameters array 'Object[] args' allocation", issues[1].description);
         }
     }
 }


### PR DESCRIPTION
[Problem]
Param array allocations are currently reported like any other allocation but there is no information on whether this is the result of a [params](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/params) attribute.

[Solution]
This PR introduces support for reporting _params_ object allocations. Note that by doing this, such allocations are reported both as "Array allocation" and "Param Object allocation".

![param-alloc](https://user-images.githubusercontent.com/12098182/180781772-460c881e-717e-4ddd-94ca-ce15b54c8eb8.PNG)

