### PR TITLE
Enable text search on custom properties

### DIFF
--- a/Editor/UI/Framework/AnalysisView.cs
+++ b/Editor/UI/Framework/AnalysisView.cs
@@ -132,7 +132,7 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                 m_DependencyView = new DependencyView(new TreeViewState(), m_Desc.onOpenIssue);
 
             if (m_TextFilter == null)
-                m_TextFilter = new TextFilter();
+                m_TextFilter = new TextFilter(layout.properties);
 
             var helpButtonTooltip = string.Format("Open Reference for {0}", m_Desc.name);
             m_HelpButtonContent = Utility.GetIcon(Utility.IconType.Help, helpButtonTooltip);

--- a/Editor/UI/Framework/Unity.ProjectAuditor.Editor.UI.Framework.api
+++ b/Editor/UI/Framework/Unity.ProjectAuditor.Editor.UI.Framework.api
@@ -8,7 +8,7 @@ namespace Unity.ProjectAuditor.Editor
         public bool ignoreCase = true;
         public bool searchDependencies = false;
         public string searchString;
-        public TextFilter() {}
+        public TextFilter(PropertyDefinition[] propertyDefinitions = default(PropertyDefinition[])) {}
         public bool Match(ProjectIssue issue);
     }
 }


### PR DESCRIPTION
**Problem statement**
Text search only works on description and filename (see [here ](https://github.com/Unity-Technologies/ProjectAuditor/blob/ef5a7479d0ef65ca52d6d87a382ab1786e414359/Editor/UI/Framework/TextFilter.cs#L13)for reference)

**Solution**
Search through all custom string properties too.