### PR TITLE
AssetDatabase.FindAssets diagnostic

### DIFF
--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -1472,6 +1472,14 @@
           "areas": ["CPU"],
           "problem": "<b>System.AppDomain.GetAssemblies</b> is expensive.",
           "solution": "Try to minimize calls to <b>System.AppDomain.GetAssemblies</b> by caching the returned assemblies. When possible, use <b>UnityEditor.TypeCache</b> for fast access to types, methods and fields."
+        },
+        {
+          "id": "PAC0232",
+          "type": "UnityEditor.AssetDatabase",
+          "method": "FindAssets",
+          "areas": ["CPU"],
+          "problem": "<b>UnityEditor.AssetDatabase.FindAssets</b> is expensive and can slow down the Editor for long periods of time on large projects.",
+          "solution": "Try to minimize calls to <b>UnityEditor.AssetDatabase.FindAssets</b>."
         }
     ]
 }

--- a/Tests/Editor/CodeAnalysis/EditorCodeAnalysisTests.cs
+++ b/Tests/Editor/CodeAnalysis/EditorCodeAnalysisTests.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.EditorTests
     public class EditorCodeAnalysisTests
     {
         [Test]
-        public void EditorCodeAnalysis_Issue_IsFound()
+        public void EditorCodeAnalysis_GetAssemblies_IsFound()
         {
             var config = ScriptableObject.CreateInstance<ProjectAuditorConfig>();
             config.CompilationMode = CompilationMode.Editor;
@@ -23,6 +23,23 @@ namespace Unity.ProjectAuditor.EditorTests
 
             Assert.NotNull(codeIssue);
             Assert.AreEqual("'System.AppDomain.GetAssemblies' usage", codeIssue.description);
+        }
+
+        [Test]
+        public void EditorCodeAnalysis_FindAssets_IsFound()
+        {
+            var config = ScriptableObject.CreateInstance<ProjectAuditorConfig>();
+            config.CompilationMode = CompilationMode.Editor;
+
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor(config);
+            var projectReport = projectAuditor.Audit();
+
+            var issues = projectReport.GetIssues(IssueCategory.Code);
+            var codeIssue = issues.FirstOrDefault(i => i.descriptor.type.Equals("UnityEditor.AssetDatabase") && i.descriptor.method.Equals("FindAssets") && i.GetCustomProperty(CodeProperty.Assembly).Equals("Unity.ProjectAuditor.Editor"));
+
+            Assert.NotNull(codeIssue);
+            Assert.AreEqual("'UnityEditor.AssetDatabase.FindAssets' usage", codeIssue.description);
+            Assert.AreEqual("PAC0232", codeIssue.descriptor.id);
         }
     }
 }


### PR DESCRIPTION
**Problem Statement**
Calls to `UnityEditor.AssetDatabase.FindAssets` are expensive and can slow down the Editor for long periods of time on large projects.

**Solution**
Add a diagnostic to surface all calls to `UnityEditor.AssetDatabase.FindAssets`.

![find-assets](https://user-images.githubusercontent.com/12098182/191232256-0166393f-278e-41ac-b43d-12d1c22ac067.PNG)
