### PR TITLE
InitializeOnLoadAttribute/InitializeOnLoadMethodAttribute diagnostics

### DIFF
--- a/Editor/CodeAnalysis/CallCrawler.cs
+++ b/Editor/CodeAnalysis/CallCrawler.cs
@@ -82,6 +82,8 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
 
                     const int depth = 0;
                     var root = issue.dependencies;
+                    if (root == null)
+                        continue;
                     BuildHierarchy(root as CallTreeNode, depth);
 
                     // temp fix for null location (code analysis was unable to get sequence point)

--- a/Editor/CodeAnalysis/MonoCecilHelper.cs
+++ b/Editor/CodeAnalysis/MonoCecilHelper.cs
@@ -40,5 +40,14 @@ namespace Unity.ProjectAuditor.Editor.CodeAnalysis
 
             return false;
         }
+
+        public static CustomAttribute GetCustomAttribute<T>(IMemberDefinition memberDefinition)
+        {
+            if (!memberDefinition.HasCustomAttributes)
+                return null;
+
+            var attrNameHash = typeof(T).FullName.GetHashCode();
+            return memberDefinition.CustomAttributes.SingleOrDefault(attr => attr.AttributeType.FullName.GetHashCode() == attrNameHash);
+        }
     }
 }


### PR DESCRIPTION
**Problem statement**
Heavy usage of InitializeOnLoad and InitializeOnLoadMethod can increase editor iteration times.

**Solution**
Add _InitializeOnLoadAttribute_ and _InitializeOnLoadMethodAttribute_ diagnostics