### PR TITLE
Ignoring three graphics evaluators if we don't use built-in RP

### DIFF
--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -224,7 +224,7 @@
             "id": "PAS0022",
             "description": "Graphics: Shader Quality",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
-            "customevaluator": "GraphicsMixedStandardShaderQuality",
+            "customevaluator": "GraphicsMixedStandardShaderQuality_WithBuiltinRenderPipeline",
             "areas": ["BuildSize"],
             "problem": "The current build target Graphics Tier Settings use a mixture of different values (Low/Medium/High) for the <b>Standard Shader Quality</b> setting. This will result in a larger number of shader variants being compiled, which will increase build times and your application's download/install size.",
             "solution": "Unless you support devices with a very wide range of capabilities for a particular platform, consider editing the platform in Graphics Settings to use the same shader quality setting across all Graphics Tiers."
@@ -233,7 +233,7 @@
             "id": "PAS0023",
             "description": "Graphics: Forward Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
-            "customevaluator": "GraphicsUsingForwardRendering",
+            "customevaluator": "GraphicsUsingForwardRendering_WithBuiltinRenderPipeline",
             "areas": ["GPU"],
             "problem": "The current build target uses forward rendering, as set in the <b>Rendering Path</b> settings in <b>Project Settings ➔ Graphics ➔ Tier Settings</b>.",
             "solution": "This rendering path is suitable for games with simple rendering and lighting requirements - for instance, 2D games, or games which mainly use baked lighting. If the project makes use of a more than a few dynamic lights, consider experimenting with changing <b>Rendering Path</b> to Deferred to see whether doing so improves GPU rendering times."
@@ -242,7 +242,7 @@
             "id": "PAS0024",
             "description": "Graphics: Deferred Rendering",
             "type": "UnityEditor.Rendering.EditorGraphicsSettings",
-            "customevaluator": "GraphicsUsingDeferredRendering",
+            "customevaluator": "GraphicsUsingDeferredRendering_WithBuiltinRenderPipeline",
             "areas": ["GPU"],
             "problem": "The current build target uses deferred rendering, as set in the <b>Rendering Path</b> settings in <b>Project Settings ➔ Graphics ➔ Tier Settings</b>.",
             "solution": "This rendering path is suitable for games with more complex rendering requirements - for instance, games that make uses of dynamic lighting or certain types of fullscreen post-processing effects. If the project doesn't make use of such rendering techniques, consider experimenting with changing <b>Rendering Path</b> to Forward to see whether doing so improves GPU rendering times."

--- a/Editor/SettingsAnalysis/Evaluators.cs
+++ b/Editor/SettingsAnalysis/Evaluators.cs
@@ -203,24 +203,42 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
             return usingDefaultAsyncUploadBufferSize;
         }
 
-        public static bool GraphicsMixedStandardShaderQuality(BuildTarget platform)
+        public static bool GraphicsMixedStandardShaderQuality_WithBuiltinRenderPipeline(BuildTarget platform)
         {
+            // Only check for Built-In Rendering Pipeline 
+            if (GraphicsSettings.defaultRenderPipeline != null)
+            {
+                return false;
+            }
+            
             var buildGroup = BuildPipeline.GetBuildTargetGroup(platform);
             var standardShaderQualities = k_GraphicsTiers.Select(tier => EditorGraphicsSettings.GetTierSettings(buildGroup, tier).standardShaderQuality);
 
             return standardShaderQualities.Distinct().Count() > 1;
         }
 
-        public static bool GraphicsUsingForwardRendering(BuildTarget platform)
+        public static bool GraphicsUsingForwardRendering_WithBuiltinRenderPipeline(BuildTarget platform)
         {
+            // Only check for Built-In Rendering Pipeline 
+            if (GraphicsSettings.defaultRenderPipeline != null)
+            {
+                return false;
+            }
+
             var buildGroup = BuildPipeline.GetBuildTargetGroup(platform);
             var renderingPaths = k_GraphicsTiers.Select(tier => EditorGraphicsSettings.GetTierSettings(buildGroup, tier).renderingPath);
 
             return renderingPaths.Any(path => path == RenderingPath.Forward);
         }
 
-        public static bool GraphicsUsingDeferredRendering(BuildTarget platform)
+        public static bool GraphicsUsingDeferredRendering_WithBuiltinRenderPipeline(BuildTarget platform)
         {
+            // Only check for Built-In Rendering Pipeline 
+            if (GraphicsSettings.defaultRenderPipeline != null)
+            {
+                return false;
+            }
+
             var buildGroup = BuildPipeline.GetBuildTargetGroup(platform);
             var renderingPaths = k_GraphicsTiers.Select(tier => EditorGraphicsSettings.GetTierSettings(buildGroup, tier).renderingPath);
 

--- a/Tests/Editor/SettingsAnalysisTests.cs
+++ b/Tests/Editor/SettingsAnalysisTests.cs
@@ -126,7 +126,7 @@ namespace Unity.ProjectAuditor.EditorTests
 
         [TestCase(false)]
         [TestCase(true)]
-        public void SettingsAnalysis_GraphicsMixedStandardShaderQuality_IsReported(bool isMixed)
+        public void SettingsAnalysis_GraphicsMixedStandardShaderQuality_WithBuiltinRenderPipeline_IsReported(bool isMixed)
         {
             var buildTarget = EditorUserBuildSettings.activeBuildTarget;
             var buildGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
@@ -137,6 +137,8 @@ namespace Unity.ProjectAuditor.EditorTests
             var tier1settings = EditorGraphicsSettings.GetTierSettings(buildGroup, GraphicsTier.Tier1);
             var tier2settings = EditorGraphicsSettings.GetTierSettings(buildGroup, GraphicsTier.Tier2);
             var tier3settings = EditorGraphicsSettings.GetTierSettings(buildGroup, GraphicsTier.Tier3);
+
+            var defaultRenderPipeline = GraphicsSettings.defaultRenderPipeline;
 
             tier1settings.standardShaderQuality = ShaderQuality.High;
             tier2settings.standardShaderQuality = ShaderQuality.High;
@@ -146,16 +148,20 @@ namespace Unity.ProjectAuditor.EditorTests
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier2, tier2settings);
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier3, tier3settings);
 
-            Assert.AreEqual(isMixed, Evaluators.GraphicsMixedStandardShaderQuality(buildTarget));
+            GraphicsSettings.defaultRenderPipeline = null;
+
+            Assert.AreEqual(isMixed, Evaluators.GraphicsMixedStandardShaderQuality_WithBuiltinRenderPipeline(buildTarget));
 
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier1, savedTier1settings);
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier2, savedTier2settings);
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier3, savedTier3settings);
+            
+            GraphicsSettings.defaultRenderPipeline = defaultRenderPipeline;
         }
 
         [TestCase(RenderingPath.Forward)]
         [TestCase(RenderingPath.DeferredShading)]
-        public void SettingsAnalysis_GraphicsUsingRenderingPath_IsReported(RenderingPath renderingPath)
+        public void SettingsAnalysis_GraphicsUsingRenderingPath_WithBuiltinRenderPipeline_IsReported(RenderingPath renderingPath)
         {
             var buildTarget = EditorUserBuildSettings.activeBuildTarget;
             var buildGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
@@ -167,6 +173,8 @@ namespace Unity.ProjectAuditor.EditorTests
             var tier2settings = EditorGraphicsSettings.GetTierSettings(buildGroup, GraphicsTier.Tier2);
             var tier3settings = EditorGraphicsSettings.GetTierSettings(buildGroup, GraphicsTier.Tier3);
 
+            var defaultRenderPipeline = GraphicsSettings.defaultRenderPipeline;
+            
             tier1settings.renderingPath = renderingPath;
             tier2settings.renderingPath = renderingPath;
             tier3settings.renderingPath = renderingPath;
@@ -175,20 +183,24 @@ namespace Unity.ProjectAuditor.EditorTests
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier2, tier2settings);
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier3, tier3settings);
 
+            GraphicsSettings.defaultRenderPipeline = null;
+
             if (renderingPath == RenderingPath.Forward)
             {
-                Assert.AreEqual(true, Evaluators.GraphicsUsingForwardRendering(buildTarget));
-                Assert.AreEqual(false, Evaluators.GraphicsUsingDeferredRendering(buildTarget));
+                Assert.AreEqual(true, Evaluators.GraphicsUsingForwardRendering_WithBuiltinRenderPipeline(buildTarget));
+                Assert.AreEqual(false, Evaluators.GraphicsUsingDeferredRendering_WithBuiltinRenderPipeline(buildTarget));
             }
             else
             {
-                Assert.AreEqual(false, Evaluators.GraphicsUsingForwardRendering(buildTarget));
-                Assert.AreEqual(true, Evaluators.GraphicsUsingDeferredRendering(buildTarget));
+                Assert.AreEqual(false, Evaluators.GraphicsUsingForwardRendering_WithBuiltinRenderPipeline(buildTarget));
+                Assert.AreEqual(true, Evaluators.GraphicsUsingDeferredRendering_WithBuiltinRenderPipeline(buildTarget));
             }
 
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier1, savedTier1settings);
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier2, savedTier2settings);
             EditorGraphicsSettings.SetTierSettings(buildGroup, GraphicsTier.Tier3, savedTier3settings);
+            
+            GraphicsSettings.defaultRenderPipeline = defaultRenderPipeline;
         }
     }
 }


### PR DESCRIPTION
Graphics evaluators for MixedStandardShaderQuality, using Forward Rendering, and using Deferred Rendering are all returning false to not report any issue, _only if_ we don't use the Built-In Rendering Pipeline (instead URP or HDRP).

According to the RP docs a non-builtin rendering pipeline is indidated by "GraphicsSettings.defaultRenderPipeline != null".