### PR TITLE
Mesh module and analyzer

### DIFF
--- a/Editor/IssueCategory.cs
+++ b/Editor/IssueCategory.cs
@@ -25,6 +25,8 @@ namespace Unity.ProjectAuditor.Editor
         TextureDiagnostic,
         AudioClip,
         ComputeShaderVariant,
+        Mesh,
+        MeshDiagnostic,
 
         FirstCustomCategory
     }

--- a/Editor/Modules/IMeshModuleAnalyzer.cs
+++ b/Editor/Modules/IMeshModuleAnalyzer.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Unity.ProjectAuditor.Editor.Core;
+using UnityEditor;
+
+namespace Unity.ProjectAuditor.Editor.Modules
+{
+    public interface IMeshModuleAnalyzer
+    {
+        void Initialize(ProjectAuditorModule module);
+
+        IEnumerable<ProjectIssue> Analyze(BuildTarget platform, ModelImporter modelImporter);
+    }
+}

--- a/Editor/Modules/IMeshModuleAnalyzer.cs.meta
+++ b/Editor/Modules/IMeshModuleAnalyzer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab11b59b7f9f435ebbb20482ef74a919
+timeCreated: 1666203271

--- a/Editor/Modules/MeshModule.cs
+++ b/Editor/Modules/MeshModule.cs
@@ -85,7 +85,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 var modelImporter = AssetImporter.GetAtPath(pathToMesh) as ModelImporter;
                 if (modelImporter == null)
                 {
-                    continue; //continues if the object found is not a member of the Texture Group:(Texture2D, Texture3D, CubeMap, 2D Array) - Example Use: RenderTextures won't be analyzed.
+                    continue;
                 }
                 
                 var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(pathToMesh);
@@ -95,8 +95,8 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     .WithCustomProperties(
                         new object[((int)MeshProperty.Num)]
                         {
-                            mesh.vertexCount, // vertices
-                            mesh.triangles.Length, // triangles
+                            mesh.vertexCount,
+                            mesh.triangles.Length / 3, 
                             modelImporter.meshCompression,
                             size,
                             currentPlatform

--- a/Editor/Modules/MeshModule.cs
+++ b/Editor/Modules/MeshModule.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.ProjectAuditor.Editor.Core;
+using Unity.ProjectAuditor.Editor.Diagnostic;
+using UnityEngine.Profiling;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.ProjectAuditor.Editor.Modules
+{
+    public enum MeshProperty
+    {
+        VertexCount,
+        TriangleCount,
+        MeshCompression,
+        SizeOnDisk,
+        Platform,
+        Num
+    }
+
+    class MeshModule : ProjectAuditorModule
+    {
+        private static readonly IssueLayout k_MeshIssueLayout = new IssueLayout
+        {
+            category = IssueCategory.Mesh,
+            properties = new[]
+            {
+                new PropertyDefinition { type = PropertyType.Description, format = PropertyFormat.String, name = "Name", longName = "Mesh Name" },
+                new PropertyDefinition { type = PropertyTypeUtil.FromCustom(MeshProperty.VertexCount), format = PropertyFormat.String, name = "Vertex Count" },
+                new PropertyDefinition { type = PropertyTypeUtil.FromCustom(MeshProperty.TriangleCount), format = PropertyFormat.String, name = "Triangle Count" },
+                new PropertyDefinition { type = PropertyTypeUtil.FromCustom(MeshProperty.MeshCompression), format = PropertyFormat.String, name = "Compression", longName = "Mesh Compression" },
+                new PropertyDefinition { type = PropertyTypeUtil.FromCustom(MeshProperty.SizeOnDisk), format = PropertyFormat.Bytes, name = "Size", longName = "Mesh Size" },
+                new PropertyDefinition { type = PropertyType.Path, name = "Path"}
+            }
+        };
+        
+        static readonly IssueLayout k_MeshDiagnosticLayout = new IssueLayout
+        {
+            category = IssueCategory.MeshDiagnostic,
+            properties = new[]
+            {
+                new PropertyDefinition { type = PropertyType.Description, format = PropertyFormat.String, name = "Name", longName = "Mesh Name" },
+                new PropertyDefinition { type = PropertyType.Area, format = PropertyFormat.String, name = "Area", longName = "Impacted Area" },
+                new PropertyDefinition { type = PropertyType.Path, name = "Path"},
+                new PropertyDefinition { type = PropertyType.Descriptor, name = "Descriptor", defaultGroup = true, hidden = true},
+            }
+        };
+        
+        public override string name => "Meshes";
+
+        public override bool isEnabledByDefault => false;
+
+        List<IMeshModuleAnalyzer> m_Analyzers;
+        HashSet<Descriptor> m_DiagnosticDescriptors;
+
+        public override IReadOnlyCollection<IssueLayout> supportedLayouts => new IssueLayout[]
+        {
+            k_MeshIssueLayout,
+            k_MeshDiagnosticLayout
+        };
+
+        public override IReadOnlyCollection<Descriptor> supportedDescriptors => m_DiagnosticDescriptors;
+
+        public override void Initialize(ProjectAuditorConfig config)
+        {
+            m_Analyzers = new List<IMeshModuleAnalyzer>();
+            m_DiagnosticDescriptors = new HashSet<Descriptor>();
+
+            foreach (var type in TypeCache.GetTypesDerivedFrom(typeof(IMeshModuleAnalyzer)))
+                AddAnalyzer(Activator.CreateInstance(type) as IMeshModuleAnalyzer);
+        }
+
+        public override void Audit(ProjectAuditorParams projectAuditorParams, IProgress progress = null)
+        {
+            var allMeshes = AssetDatabase.FindAssets("t:mesh, a:assets");
+            var issues = new List<ProjectIssue>();
+            var currentPlatform = projectAuditorParams.platform;
+
+            progress?.Start("Finding Meshes", "Search in Progress...", allMeshes.Length);
+
+            foreach (var guid in allMeshes)
+            {
+                var pathToMesh = AssetDatabase.GUIDToAssetPath(guid);
+                var modelImporter = AssetImporter.GetAtPath(pathToMesh) as ModelImporter;
+                if (modelImporter == null)
+                {
+                    continue; //continues if the object found is not a member of the Texture Group:(Texture2D, Texture3D, CubeMap, 2D Array) - Example Use: RenderTextures won't be analyzed.
+                }
+                
+                var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(pathToMesh);
+                var size = Profiler.GetRuntimeMemorySizeLong(mesh);
+
+                var issue = ProjectIssue.Create(k_MeshIssueLayout.category, mesh.name)
+                    .WithCustomProperties(
+                        new object[((int)MeshProperty.Num)]
+                        {
+                            mesh.vertexCount, // vertices
+                            mesh.triangles.Length, // triangles
+                            modelImporter.meshCompression,
+                            size,
+                            currentPlatform
+                        })
+                    .WithLocation(new Location(pathToMesh));
+
+                issues.Add(issue);
+                
+                foreach (var analyzer in m_Analyzers)
+                {
+                    var platformDiagnostics = analyzer.Analyze(currentPlatform, modelImporter).ToArray();
+
+                    issues.AddRange(platformDiagnostics);
+                }
+
+                progress?.Advance();
+            }
+
+            if (issues.Count > 0)
+                projectAuditorParams.onIncomingIssues(issues);
+            progress?.Clear();
+
+            projectAuditorParams.onModuleCompleted?.Invoke();
+        }
+
+        void AddAnalyzer(IMeshModuleAnalyzer moduleAnalyzer)
+        {
+            moduleAnalyzer.Initialize(this);
+            m_Analyzers.Add(moduleAnalyzer);
+        }
+    }
+}

--- a/Editor/Modules/MeshModule.cs.meta
+++ b/Editor/Modules/MeshModule.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f9389d6d9bf64f60bea634118c9f8dc6
+timeCreated: 1665003573

--- a/Editor/UI/ProjectAuditorAnalytics.cs
+++ b/Editor/UI/ProjectAuditorAnalytics.cs
@@ -57,7 +57,8 @@ namespace Unity.ProjectAuditor.Editor.UI
             Textures,
             PackageVersion,
             AudioClip,
-            ComputeShaderVariants
+            ComputeShaderVariants,
+            Meshes
         }
 
         // -------------------------------------------------------------------------------------------------------------
@@ -216,6 +217,8 @@ namespace Unity.ProjectAuditor.Editor.UI
                     return "package_version";
                 case UIButton.AudioClip:
                     return "audio_clip";
+                case UIButton.Meshes:
+                    return "meshes";
                 default:
                     Debug.LogFormat("SendUIButtonEvent: Unsupported button type : {0}", uiButton);
                     return "";

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -470,6 +470,39 @@ namespace Unity.ProjectAuditor.Editor.UI
                     onOpenIssue = EditorUtil.FocusOnAssetInProjectWindow,
                     analyticsEvent = (int)ProjectAuditorAnalytics.UIButton.PrecompiledAssemblies
                 });
+                
+                ViewDescriptor.Register(new ViewDescriptor
+                {
+                    category = IssueCategory.Mesh,
+                    name = "Meshes",
+                    menuLabel = "Assets/Meshes/Meshes",
+                    menuOrder = 7,
+                    descriptionWithIcon = true,
+                    showFilters = true,
+                    onOpenIssue = EditorUtil.FocusOnAssetInProjectWindow,
+                    onDrawToolbar = (viewManager) =>
+                    {
+                        AnalysisView.DrawToolbarButton(Contents.MeshDiagnostics, () => viewManager.ChangeView(IssueCategory.MeshDiagnostic));
+                    },
+                    analyticsEvent = (int)ProjectAuditorAnalytics.UIButton.Meshes
+                });
+                
+                ViewDescriptor.Register(new ViewDescriptor
+                {
+                    category = IssueCategory.MeshDiagnostic,
+                    name = "Mesh Diagnostics",
+                    menuLabel = "Assets/Meshes/Diagnostics",
+                    menuOrder = 8,
+                    descriptionWithIcon = true,
+                    showFilters = true,
+                    onOpenIssue = EditorUtil.FocusOnAssetInProjectWindow,
+                    onDrawToolbar = (viewManager) =>
+                    {
+                        AnalysisView.DrawToolbarButton(Contents.Meshes, () => viewManager.ChangeView(IssueCategory.Mesh));
+                    },
+                    type = typeof(DiagnosticView),
+                    analyticsEvent = (int)ProjectAuditorAnalytics.UIButton.Meshes
+                });
             }
             ViewDescriptor.Register(new ViewDescriptor
             {
@@ -1421,6 +1454,9 @@ A view allows the user to browse through the listed items and filter by string o
 
             public static readonly GUIContent Textures = new GUIContent("Textures");
             public static readonly GUIContent TextureDiagnostics = new GUIContent("Diagnostics", "Texture Diagnostics");
+
+            public static readonly GUIContent Meshes = new GUIContent("Meshes");
+            public static readonly GUIContent MeshDiagnostics = new GUIContent("Diagnostics", "Mesh Diagnostics");
 
             public static readonly GUIContent BuildFiles = new GUIContent("Build Size");
             public static readonly GUIContent BuildSteps = new GUIContent("Build Steps");


### PR DESCRIPTION
Added a simple MeshModule and IMeshModuleAnalyzer interface to have the general logic ready for further mesh analyzers.

There is a Mesh & MeshDiagnostics tab included.

Category.Mesh stats are basic, similar to Texture (name, vertex/triangle counts, mesh compression, size on disk, path).