### PR TITLE
Texture analyzer

### DIFF
--- a/Documentation~/Diagnostics.md
+++ b/Documentation~/Diagnostics.md
@@ -11,6 +11,7 @@ Note that there are different ranges within both Code and Settings diagnostic ID
 - Settings:
   - `PAS0xxx`: Unity settings 
   - `PAS1xxx`: other settings IDs defined in code rather than in the json
+  - `PAT0xxx`: texture related settings
 
 # Settings Diagnostics
 This is a full list of all builtin settings diagnostics:
@@ -50,5 +51,5 @@ This is a full list of all builtin settings diagnostics:
 | PAS1000 | Hybrid Rendering Static batching            | Player    | Any                      |
 | PAS1001 | Lit Shader Mode Forward and Deferred        | HDRP      | Any                      |
 | PAS1002 | Camera Lit Shader Mode Forward and Deferred | HDRP      | Any                      |
-| PAS1003 | Texture: Mip Maps not enabled               | Graphics  | Any                      |
-| PAS1004 | Texture: Mip Maps enabled on 2D texture     | Graphics  | Any                      |
+| PAT0000 | Texture: Mip Maps not enabled               | Graphics  | Any                      |
+| PAT0001 | Texture: Mip Maps enabled on 2D texture     | Graphics  | Any                      |

--- a/Documentation~/Diagnostics.md
+++ b/Documentation~/Diagnostics.md
@@ -50,3 +50,5 @@ This is a full list of all builtin settings diagnostics:
 | PAS1000 | Hybrid Rendering Static batching            | Player    | Any                      |
 | PAS1001 | Lit Shader Mode Forward and Deferred        | HDRP      | Any                      |
 | PAS1002 | Camera Lit Shader Mode Forward and Deferred | HDRP      | Any                      |
+| PAS1003 | Texture: Mip Maps not enabled               | Graphics  | Any                      |
+| PAS1004 | Texture: Mip Maps enabled on 2D texture     | Graphics  | Any                      |

--- a/Editor/TextureAnalyzer.cs
+++ b/Editor/TextureAnalyzer.cs
@@ -13,7 +13,7 @@ namespace Unity.ProjectAuditor.Editor
             "PAS1003",
             "Texture: Mip Maps not enabled",
             new[] {Area.GPU, Area.Quality},
-            "Texture's Mip Maps are not enabled.",
+            "Texture's Mip Maps are not enabled.\n\nGenerally enabling mip maps improves rendering quality (avoids aliasing effects) and improves performance.",
             "Select the texture asset and, if applicable, enable texture importer option <b>Advanced / Generate Mip Maps</b>."
         )
         {

--- a/Editor/TextureAnalyzer.cs
+++ b/Editor/TextureAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Unity.ProjectAuditor.Editor
     public class TextureAnalyzer : ITextureModuleAnalyzer
     {
         internal static readonly Descriptor k_TextureMipMapNotEnabledDescriptor = new Descriptor(
-            "PAS1003",
+            "PAT0000",
             "Texture: Mip Maps not enabled",
             new[] {Area.GPU, Area.Quality},
             "Texture's Mip Maps are not enabled.\n\nGenerally enabling mip maps improves rendering quality (avoids aliasing effects) and improves performance.",
@@ -21,10 +21,10 @@ namespace Unity.ProjectAuditor.Editor
         };
         
         internal static readonly Descriptor k_TextureMipMapEnabledDescriptor = new Descriptor(
-            "PAS1004",
+            "PAT0001",
             "Texture: Mip Maps enabled on 2D texture",
             new[] {Area.Quality},
-            "Texture's Mip Maps are enabled on textures that may reduce rendering quality for Sprites or GUI.\n\nPlease verify if this is relevant for this texture.",
+            "Texture's Mip Maps are enabled on textures that may reduce rendering quality for Sprites or GUI. Disabling Mip Maps also reduces your build size.\n\nPlease verify if this is relevant for this texture.",
             "Select the texture asset and, if applicable, disable texture importer option <b>Advanced / Generate Mip Maps</b>."
         )
         {

--- a/Editor/TextureAnalyzer.cs
+++ b/Editor/TextureAnalyzer.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.IO;
+using Unity.ProjectAuditor.Editor.Core;
+using Unity.ProjectAuditor.Editor.Diagnostic;
+using Unity.ProjectAuditor.Editor.Modules;
+using UnityEditor;
+
+namespace Unity.ProjectAuditor.Editor
+{
+    public class TextureAnalyzer : ITextureModuleAnalyzer
+    {
+        internal static readonly Descriptor k_TextureMipMapNotEnabledDescriptor = new Descriptor(
+            "PAS1003",
+            "Texture: Mip Maps not enabled",
+            new[] {Area.GPU, Area.Quality},
+            "Texture's Mip Maps are not enabled.",
+            "Select the texture asset and, if applicable, enable texture importer option <b>Advanced / Generate Mip Maps</b>."
+        )
+        {
+            messageFormat = "Texture '{0}' mip maps are not enabled"
+        };
+        
+        internal static readonly Descriptor k_TextureMipMapEnabledDescriptor = new Descriptor(
+            "PAS1004",
+            "Texture: Mip Maps enabled on 2D texture",
+            new[] {Area.Quality},
+            "Texture's Mip Maps are enabled on textures that may reduce rendering quality for Sprites or GUI.\n\nPlease verify if this is relevant for this texture.",
+            "Select the texture asset and, if applicable, disable texture importer option <b>Advanced / Generate Mip Maps</b>."
+        )
+        {
+            messageFormat = "Texture '{0}' mip maps are enabled"
+        };
+
+        public void Initialize(ProjectAuditorModule module)
+        {
+            module.RegisterDescriptor(k_TextureMipMapNotEnabledDescriptor);
+            module.RegisterDescriptor(k_TextureMipMapEnabledDescriptor);
+        }
+
+        public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, TextureImporter textureImporter, TextureImporterPlatformSettings textureImporterPlatformSettings)
+        {
+            if (textureImporter.mipmapEnabled == false && textureImporter.textureType == TextureImporterType.Default)
+            {
+                var assetPath = textureImporter.assetPath;
+                var textureName = Path.GetFileNameWithoutExtension(assetPath);
+
+                yield return ProjectIssue.Create(IssueCategory.TextureDiagnostic,
+                        k_TextureMipMapNotEnabledDescriptor, textureName)
+                    .WithLocation(assetPath);
+            }
+            
+            if (textureImporter.mipmapEnabled == true &&
+                (textureImporter.textureType == TextureImporterType.Sprite || textureImporter.textureType == TextureImporterType.GUI)
+                )
+            {
+                var assetPath = textureImporter.assetPath;
+                var textureName = Path.GetFileNameWithoutExtension(assetPath);
+
+                yield return ProjectIssue.Create(IssueCategory.TextureDiagnostic,
+                        k_TextureMipMapEnabledDescriptor, textureName)
+                    .WithLocation(assetPath);
+            }
+            
+        }
+    }
+}

--- a/Editor/TextureAnalyzer.cs.meta
+++ b/Editor/TextureAnalyzer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5cf5442caa5c4e8eb92accb2b3dd68cd
+timeCreated: 1666280648

--- a/Tests/Editor/TextureTests.cs
+++ b/Tests/Editor/TextureTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
 using Unity.ProjectAuditor.Editor.Modules;
@@ -10,9 +11,18 @@ namespace Unity.ProjectAuditor.EditorTests
     class TextureTests : TestFixtureBase
     {
         const string k_TextureName = "ProceduralTextureForTest3212";
+        const string k_TextureNameMipMapDefault = k_TextureName + "MipMapDefaultTest1234";
+        const string k_TextureNameNoMipMapDefault = k_TextureName + "NoMipMapDefaultTest1234";
+        const string k_TextureNameMipMapGUI = k_TextureName + "MipMapGUITest1234";
+        const string k_TextureNameMipMapSprite = k_TextureName + "MipMapSpriteTest1234";
+
         const int k_Resolution = 1;
 
         TempAsset m_TempTexture;
+        TempAsset m_TempTextureMipMapDefault;
+        TempAsset m_TempTextureNoMipMapDefault;
+        TempAsset m_TempTextureMipMapGUI;
+        TempAsset m_TempTextureMipMapSprite;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -23,6 +33,34 @@ namespace Unity.ProjectAuditor.EditorTests
             texture.Apply();
 
             m_TempTexture = new TempAsset(k_TextureName + ".png", texture.EncodeToPNG());
+
+            m_TempTextureMipMapDefault = new TempAsset(k_TextureNameMipMapDefault + ".png", texture.EncodeToPNG());
+            
+            var textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapDefault.relativePath) as TextureImporter;
+            textureImporter.textureType = TextureImporterType.Default;
+            textureImporter.mipmapEnabled = true;
+            textureImporter.SaveAndReimport();
+
+            m_TempTextureNoMipMapDefault = new TempAsset(k_TextureNameNoMipMapDefault + ".png", texture.EncodeToPNG());
+
+            textureImporter = AssetImporter.GetAtPath(m_TempTextureNoMipMapDefault.relativePath) as TextureImporter;
+            textureImporter.textureType = TextureImporterType.Default;
+            textureImporter.mipmapEnabled = false;
+            textureImporter.SaveAndReimport();
+            
+            m_TempTextureMipMapGUI = new TempAsset(k_TextureNameMipMapGUI + ".png", texture.EncodeToPNG());
+            
+            textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapGUI.relativePath) as TextureImporter;
+            textureImporter.textureType = TextureImporterType.GUI;
+            textureImporter.mipmapEnabled = true;
+            textureImporter.SaveAndReimport();
+            
+            m_TempTextureMipMapSprite = new TempAsset(k_TextureNameMipMapSprite + ".png", texture.EncodeToPNG());
+            
+            textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapSprite.relativePath) as TextureImporter;
+            textureImporter.textureType = TextureImporterType.Sprite;
+            textureImporter.mipmapEnabled = true;
+            textureImporter.SaveAndReimport();
         }
 
         [Test]
@@ -54,5 +92,39 @@ namespace Unity.ProjectAuditor.EditorTests
             Assert.AreEqual(Profiler.GetRuntimeMemorySizeLong(texture).ToString(), reportedTexture.GetCustomProperty(TextureProperty.SizeOnDisk), "Checked Texture Size");
             */
         }
+        
+        
+        [Test]
+        public void Texture_MipMapUnused_IsReported() 
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureNoMipMapDefault, IssueCategory.TextureDiagnostic).FirstOrDefault(i => i.descriptor == TextureAnalyzer.k_TextureMipMapNotEnabledDescriptor);
+
+            Assert.NotNull(textureDiagnostic);
+        }
+        
+        [Test]
+        public void Texture_MipMapUnused_IsNotReported() 
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapDefault, IssueCategory.TextureDiagnostic).FirstOrDefault(i => i.descriptor == TextureAnalyzer.k_TextureMipMapNotEnabledDescriptor);
+
+            Assert.Null(textureDiagnostic);
+        }
+        
+        [Test]
+        public void Texture_MipMapUsedForGUI_IsReported() 
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapGUI, IssueCategory.TextureDiagnostic).FirstOrDefault(i => i.descriptor == TextureAnalyzer.k_TextureMipMapEnabledDescriptor);
+
+            Assert.NotNull(textureDiagnostic);
+        }
+        
+        [Test]
+        public void Texture_MipMapUsedForSprite_IsReported() 
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapSprite, IssueCategory.TextureDiagnostic).FirstOrDefault(i => i.descriptor == TextureAnalyzer.k_TextureMipMapEnabledDescriptor);
+
+            Assert.NotNull(textureDiagnostic);
+        }
+
     }
 }

--- a/Tests/Editor/TextureTests.cs
+++ b/Tests/Editor/TextureTests.cs
@@ -32,30 +32,32 @@ namespace Unity.ProjectAuditor.EditorTests
             texture.name = k_TextureName;
             texture.Apply();
 
-            m_TempTexture = new TempAsset(k_TextureName + ".png", texture.EncodeToPNG());
+            var encodedPNG = texture.EncodeToPNG();
 
-            m_TempTextureMipMapDefault = new TempAsset(k_TextureNameMipMapDefault + ".png", texture.EncodeToPNG());
+            m_TempTexture = new TempAsset(k_TextureName + ".png", encodedPNG);
+
+            m_TempTextureMipMapDefault = new TempAsset(k_TextureNameMipMapDefault + ".png", encodedPNG);
             
             var textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapDefault.relativePath) as TextureImporter;
             textureImporter.textureType = TextureImporterType.Default;
             textureImporter.mipmapEnabled = true;
             textureImporter.SaveAndReimport();
 
-            m_TempTextureNoMipMapDefault = new TempAsset(k_TextureNameNoMipMapDefault + ".png", texture.EncodeToPNG());
+            m_TempTextureNoMipMapDefault = new TempAsset(k_TextureNameNoMipMapDefault + ".png", encodedPNG);
 
             textureImporter = AssetImporter.GetAtPath(m_TempTextureNoMipMapDefault.relativePath) as TextureImporter;
             textureImporter.textureType = TextureImporterType.Default;
             textureImporter.mipmapEnabled = false;
             textureImporter.SaveAndReimport();
             
-            m_TempTextureMipMapGUI = new TempAsset(k_TextureNameMipMapGUI + ".png", texture.EncodeToPNG());
+            m_TempTextureMipMapGUI = new TempAsset(k_TextureNameMipMapGUI + ".png", encodedPNG);
             
             textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapGUI.relativePath) as TextureImporter;
             textureImporter.textureType = TextureImporterType.GUI;
             textureImporter.mipmapEnabled = true;
             textureImporter.SaveAndReimport();
             
-            m_TempTextureMipMapSprite = new TempAsset(k_TextureNameMipMapSprite + ".png", texture.EncodeToPNG());
+            m_TempTextureMipMapSprite = new TempAsset(k_TextureNameMipMapSprite + ".png", encodedPNG);
             
             textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapSprite.relativePath) as TextureImporter;
             textureImporter.textureType = TextureImporterType.Sprite;


### PR DESCRIPTION
Adding texture analyzer for mip maps, and unit tests:

- Default texture type is reported if Mip Maps are disabled
- Sprite and GUI texture types are reported if Mip Maps are enabled