### PR TITLE
Fix buildreport object name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added on-demand _AudioClip_ module
 * Added Compute Shader Variants support
 * Fixed over-reporting of built shader variants count
+* Fixed Build Report object name
 * Improved text search to match custom properties
 * Fix export of filtered/selected non-diagnostic issues
 

--- a/Editor/Modules/BuildReportModule.cs
+++ b/Editor/Modules/BuildReportModule.cs
@@ -54,14 +54,18 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 Directory.CreateDirectory(k_BuildReportDir);
 
             var date = File.GetLastWriteTime(k_LastBuildReportPath);
-            var assetPath = k_BuildReportDir + "/Build_" + date.ToString("yyyy-MM-dd-HH-mm-ss") + ".buildreport";
+            var targetAssetName = "Build_" + date.ToString("yyyy-MM-dd-HH-mm-ss");
+            var assetPath = $"{k_BuildReportDir}/{targetAssetName}.buildreport";
 
             if (!File.Exists(assetPath))
             {
                 if (!File.Exists(k_LastBuildReportPath))
                     return null; // the project was never built
-                File.Copy(k_LastBuildReportPath, assetPath, true);
-                AssetDatabase.ImportAsset(assetPath);
+
+                var tempAssetPath = k_BuildReportDir + "/New Report.buildreport";
+                File.Copy(k_LastBuildReportPath, tempAssetPath, true);
+                AssetDatabase.ImportAsset(tempAssetPath);
+                AssetDatabase.RenameAsset(tempAssetPath, targetAssetName);
             }
 
             return AssetDatabase.LoadAssetAtPath<BuildReport>(assetPath);

--- a/Tests/Editor/BuildReportTests.cs
+++ b/Tests/Editor/BuildReportTests.cs
@@ -36,6 +36,20 @@ namespace Unity.ProjectAuditor.EditorTests
 #if !BUILD_REPORT_API_SUPPORT
         [Ignore("Not Supported in this version of Unity")]
 #endif
+        public void BuildReport_ObjectName_IsCorrect()
+        {
+            Build();
+            var buildReport = BuildReportModule.BuildReportProvider.GetBuildReport();
+            var assetPath = AssetDatabase.GetAssetPath(buildReport);
+            var assetName = Path.GetFileNameWithoutExtension(assetPath);
+            Assert.AreEqual(assetName, buildReport.name);
+            Assert.True(assetName.StartsWith("Build_"));
+        }
+
+        [Test]
+#if !BUILD_REPORT_API_SUPPORT
+        [Ignore("Not Supported in this version of Unity")]
+#endif
         public void BuildReport_Files_AreReported()
         {
             var issues = AnalyzeBuild(IssueCategory.BuildFile, i => i.relativePath.Equals(m_TempAsset.relativePath));


### PR DESCRIPTION
Project Auditor suffers from the same problem described by
https://github.com/Unity-Technologies/BuildReportInspector/issues/27

This is a fix that.