### PR TITLE
Add AnalysisPlatform Attribute to constrain analysis

### DIFF
--- a/Editor/Core/AnalysisPlatformAttribute.cs
+++ b/Editor/Core/AnalysisPlatformAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using UnityEditor;
+
+namespace Unity.ProjectAuditor.Editor.Core
+{
+    public class AnalysisPlatformAttribute : Attribute
+    {
+        public BuildTarget platform { get;}
+
+        public AnalysisPlatformAttribute(BuildTarget platform)
+        {
+            this.platform = platform;
+        }
+    }
+}

--- a/Editor/Core/AnalysisPlatformAttribute.cs.meta
+++ b/Editor/Core/AnalysisPlatformAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dd5733162b1042bd821b55a4ce47ab55
+timeCreated: 1666598555

--- a/Editor/Core/CoreUtils.cs
+++ b/Editor/Core/CoreUtils.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+
+namespace Unity.ProjectAuditor.Editor.Core
+{
+    internal static class CoreUtils
+    {
+        public static bool HasPlatformAttribute(Type type, BuildTarget platform)
+        {
+            if (!type.CustomAttributes.Any())
+                return true;
+            return type.GetCustomAttributes<AnalysisPlatformAttribute>().Any(a => a.platform == platform);
+        }
+    }
+}

--- a/Editor/Core/CoreUtils.cs
+++ b/Editor/Core/CoreUtils.cs
@@ -7,7 +7,7 @@ namespace Unity.ProjectAuditor.Editor.Core
 {
     internal static class CoreUtils
     {
-        public static bool HasPlatformAttribute(Type type, BuildTarget platform)
+        public static bool SupportsPlatform(Type type, BuildTarget platform)
         {
             if (!type.CustomAttributes.Any())
                 return true;

--- a/Editor/Core/CoreUtils.cs.meta
+++ b/Editor/Core/CoreUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a174304c92824856916404b55c518f58
+timeCreated: 1666604201

--- a/Editor/Modules/SettingsModule.cs
+++ b/Editor/Modules/SettingsModule.cs
@@ -52,7 +52,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             if (progress != null)
                 progress.Start("Analyzing Settings", "Analyzing project settings", m_Analyzers.Count);
 
-            var analyzers = m_Analyzers.Where(a => CoreUtils.HasPlatformAttribute(a.GetType(), projectAuditorParams.platform)).ToArray();
+            var analyzers = m_Analyzers.Where(a => CoreUtils.SupportsPlatform(a.GetType(), projectAuditorParams.platform)).ToArray();
             var context = new SettingsAnalyzerContext { platform = projectAuditorParams.platform};
 
             foreach (var analyzer in analyzers)

--- a/Editor/Modules/SettingsModule.cs
+++ b/Editor/Modules/SettingsModule.cs
@@ -52,9 +52,10 @@ namespace Unity.ProjectAuditor.Editor.Modules
             if (progress != null)
                 progress.Start("Analyzing Settings", "Analyzing project settings", m_Analyzers.Count);
 
+            var analyzers = m_Analyzers.Where(a => CoreUtils.HasPlatformAttribute(a.GetType(), projectAuditorParams.platform)).ToArray();
             var context = new SettingsAnalyzerContext { platform = projectAuditorParams.platform};
 
-            foreach (var analyzer in m_Analyzers)
+            foreach (var analyzer in analyzers)
             {
                 if (progress != null)
                     progress.Advance();

--- a/Editor/Modules/TextureModule.cs
+++ b/Editor/Modules/TextureModule.cs
@@ -81,6 +81,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
         public override void Audit(ProjectAuditorParams projectAuditorParams, IProgress progress = null)
         {
+            var analyzers = m_Analyzers.Where(a => CoreUtils.HasPlatformAttribute(a.GetType(), projectAuditorParams.platform)).ToArray();
             var allTextures = AssetDatabase.FindAssets("t:texture, a:assets");
             var issues = new List<ProjectIssue>();
             var currentPlatform = projectAuditorParams.platform;
@@ -119,13 +120,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     .WithLocation(new Location(assetPath));
 
                 issues.Add(issue);
-
-                foreach (var analyzer in m_Analyzers)
-                {
-                    var platformDiagnostics = analyzer.Analyze(currentPlatform, textureImporter, platformSettings).ToArray();
-
-                    issues.AddRange(platformDiagnostics);
-                }
+                issues.AddRange(analyzers.SelectMany(a => a.Analyze(currentPlatform, textureImporter, platformSettings)));
 
                 progress?.Advance();
             }

--- a/Editor/Modules/TextureModule.cs
+++ b/Editor/Modules/TextureModule.cs
@@ -81,7 +81,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
         public override void Audit(ProjectAuditorParams projectAuditorParams, IProgress progress = null)
         {
-            var analyzers = m_Analyzers.Where(a => CoreUtils.HasPlatformAttribute(a.GetType(), projectAuditorParams.platform)).ToArray();
+            var analyzers = m_Analyzers.Where(a => CoreUtils.SupportsPlatform(a.GetType(), projectAuditorParams.platform)).ToArray();
             var allTextures = AssetDatabase.FindAssets("t:texture, a:assets");
             var issues = new List<ProjectIssue>();
             var currentPlatform = projectAuditorParams.platform;

--- a/Editor/ProjectAuditor.cs
+++ b/Editor/ProjectAuditor.cs
@@ -125,7 +125,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             var result = new ProjectReport();
             var requestedModules = projectAuditorParams.categories != null ? projectAuditorParams.categories.Select(GetModule).Distinct() : m_Modules.Where(m => m.isEnabledByDefault);
-            var supportedModules = requestedModules.Where(m => m != null && m.isSupported && CoreUtils.HasPlatformAttribute(m.GetType(), projectAuditorParams.platform)).ToArray();
+            var supportedModules = requestedModules.Where(m => m != null && m.isSupported && CoreUtils.SupportsPlatform(m.GetType(), projectAuditorParams.platform)).ToArray();
             var numModules = supportedModules.Length;
             if (numModules == 0)
             {

--- a/Editor/ProjectAuditor.cs
+++ b/Editor/ProjectAuditor.cs
@@ -125,7 +125,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             var result = new ProjectReport();
             var requestedModules = projectAuditorParams.categories != null ? projectAuditorParams.categories.Select(GetModule).Distinct() : m_Modules.Where(m => m.isEnabledByDefault);
-            var supportedModules = requestedModules.Where(m => m != null && m.isSupported).ToArray();
+            var supportedModules = requestedModules.Where(m => m != null && m.isSupported && CoreUtils.HasPlatformAttribute(m.GetType(), projectAuditorParams.platform)).ToArray();
             var numModules = supportedModules.Length;
             if (numModules == 0)
             {


### PR DESCRIPTION
**Problem Statement**
As we implement platform-specific modules and analyzers we need to make sure they don't run if they don't support the currently selected analysis platform.

**Solution**
Introduce the `AnalysisPlatform `attribute which can be used on both Modules and Module analyzers. This is checked at analysis time to exclude types that are not relevant for the current analysis. If no `AnalysisPlatform `is specified, it is assumed the type is cross-platform.