### PR TITLE
Report improvements

### DIFF
--- a/Editor/ProjectAuditor.cs
+++ b/Editor/ProjectAuditor.cs
@@ -164,7 +164,7 @@ namespace Unity.ProjectAuditor.Editor
                             Debug.Log(module.name + " module took: " +
                                 (moduleEndTime - moduleStartTime).TotalMilliseconds / 1000.0 + " seconds.");
 
-                        report.RecordModuleInfo(module.name, moduleStartTime, moduleEndTime);
+                        report.RecordModuleInfo(module, moduleStartTime, moduleEndTime);
 
                         projectAuditorParams.onModuleCompleted?.Invoke();
 

--- a/Editor/ProjectAuditorParams.cs
+++ b/Editor/ProjectAuditorParams.cs
@@ -42,6 +42,8 @@ namespace Unity.ProjectAuditor.Editor
         /// </summary>
         public Action onModuleCompleted;
 
+        public ProjectReport existingReport;
+
         public ProjectAuditorParams()
         {
             platform = EditorUserBuildSettings.activeBuildTarget;
@@ -58,6 +60,8 @@ namespace Unity.ProjectAuditor.Editor
             onIncomingIssues = original.onIncomingIssues;
             onCompleted = original.onCompleted;
             onModuleCompleted = original.onModuleCompleted;
+
+            existingReport = original.existingReport;
         }
     }
 }

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -691,9 +691,6 @@ namespace Unity.ProjectAuditor.Editor.UI
 
         void AuditSingleModule(ProjectAuditorModule module)
         {
-            if (m_ProjectReport == null)
-                m_ProjectReport = new ProjectReport();
-
             var categories = module.categories;
             var views = categories
                 .Select(c => m_ViewManager.GetView(c))

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -695,11 +695,6 @@ namespace Unity.ProjectAuditor.Editor.UI
                 m_ProjectReport = new ProjectReport();
 
             var categories = module.categories;
-            foreach (var category in categories)
-            {
-                m_ProjectReport.ClearIssues(category);
-            }
-
             var views = categories
                 .Select(c => m_ViewManager.GetView(c))
                 .Where(v => v != null)
@@ -711,23 +706,23 @@ namespace Unity.ProjectAuditor.Editor.UI
                 view.Clear();
             }
 
-            var platform = m_ProjectReport.GetIssues(IssueCategory.MetaData).FirstOrDefault(i => i.description.Equals(MetaDataModule.k_KeyAnalysisTarget));
             var projectAuditorParams = new ProjectAuditorParams
             {
+                categories = categories,
                 onIncomingIssues = issues =>
                 {
                     foreach (var view in views)
                     {
                         view.AddIssues(issues);
                     }
-
-                    m_ProjectReport.AddIssues(issues);
-                }
+                },
+                existingReport = m_ProjectReport
             };
 
+            var platform = m_ProjectReport.GetIssues(IssueCategory.MetaData).FirstOrDefault(i => i.description.Equals(MetaDataModule.k_KeyAnalysisTarget));
             if (platform != null)
                 projectAuditorParams.platform = (BuildTarget)Enum.Parse(typeof(BuildTarget), platform.GetCustomProperty(MetaDataProperty.Value));
-            module.Audit(projectAuditorParams, new ProgressBar());
+            m_ProjectAuditor.Audit(projectAuditorParams, new ProgressBar());
         }
 
         public void AnalyzeShaderVariants()

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -97,6 +97,7 @@ namespace Unity.ProjectAuditor.Editor
         public string[] assemblyNames;
         public IssueCategory[] categories;
         public AssemblyUtils.CodeOptimization codeOptimization = AssemblyUtils.CodeOptimization.Release;
+        public ProjectReport existingReport;
         public System.Action<ProjectReport> onCompleted;
         public System.Action<System.Collections.Generic.IEnumerable<ProjectIssue>> onIncomingIssues;
         public System.Action onModuleCompleted;
@@ -139,14 +140,13 @@ namespace Unity.ProjectAuditor.Editor
     public sealed class ProjectReport
     {
         public int NumTotalIssues { get; }
-        public void AddIssues(System.Collections.Generic.IEnumerable<ProjectIssue> issues);
-        public void ClearIssues(IssueCategory category);
         public void ExportToCSV(string path, Core.IssueLayout layout, System.Func<ProjectIssue, bool> predicate = default(System.Func<ProjectIssue, bool>));
         public void ExportToHTML(string path, Core.IssueLayout layout, System.Func<ProjectIssue, bool> predicate = default(System.Func<ProjectIssue, bool>));
         public System.Collections.Generic.IReadOnlyCollection<ProjectIssue> GetAllIssues();
         public System.Collections.Generic.IReadOnlyCollection<ProjectIssue> GetIssues(IssueCategory category);
         public int GetNumIssues(IssueCategory category);
         public static ProjectReport Load(string path);
+        public void RecordModuleInfo(string name, System.DateTime startTime, System.DateTime endTime);
         public void Save(string path);
     }
 

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -145,8 +145,8 @@ namespace Unity.ProjectAuditor.Editor
         public System.Collections.Generic.IReadOnlyCollection<ProjectIssue> GetAllIssues();
         public System.Collections.Generic.IReadOnlyCollection<ProjectIssue> GetIssues(IssueCategory category);
         public int GetNumIssues(IssueCategory category);
+        public bool HasCategory(IssueCategory category);
         public static ProjectReport Load(string path);
-        public void RecordModuleInfo(string name, System.DateTime startTime, System.DateTime endTime);
         public void Save(string path);
     }
 

--- a/Tests/Editor/ProjectAuditorTests.cs
+++ b/Tests/Editor/ProjectAuditorTests.cs
@@ -115,10 +115,13 @@ namespace Unity.ProjectAuditor.EditorTests
             {
                 categories = new[] { IssueCategory.ProjectSetting}
             });
+
+            Assert.True(report.HasCategory(IssueCategory.ProjectSetting));
             Assert.Positive(report.GetIssues(IssueCategory.ProjectSetting).Count);
 
             report.ClearIssues(IssueCategory.ProjectSetting);
 
+            Assert.False(report.HasCategory(IssueCategory.ProjectSetting));
             Assert.Zero(report.GetIssues(IssueCategory.ProjectSetting).Count);
 
             projectAuditor.Audit(new ProjectAuditorParams
@@ -127,6 +130,7 @@ namespace Unity.ProjectAuditor.EditorTests
                 existingReport = report
             });
 
+            Assert.True(report.HasCategory(IssueCategory.ProjectSetting));
             Assert.Positive(report.GetIssues(IssueCategory.ProjectSetting).Count);
         }
     }

--- a/Tests/Editor/ProjectAuditorTests.cs
+++ b/Tests/Editor/ProjectAuditorTests.cs
@@ -110,6 +110,9 @@ namespace Unity.ProjectAuditor.EditorTests
         [Test]
         public void ProjectAuditor_Report_IsUpdated()
         {
+            var savedSetting = PlayerSettings.bakeCollisionMeshes;
+            PlayerSettings.bakeCollisionMeshes = false;
+
             var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor(m_Config);
             var report = projectAuditor.Audit(new ProjectAuditorParams
             {
@@ -132,6 +135,8 @@ namespace Unity.ProjectAuditor.EditorTests
 
             Assert.True(report.HasCategory(IssueCategory.ProjectSetting));
             Assert.Positive(report.GetIssues(IssueCategory.ProjectSetting).Count);
+
+            PlayerSettings.bakeCollisionMeshes = savedSetting;
         }
     }
 }

--- a/Tests/Editor/ProjectAuditorTests.cs
+++ b/Tests/Editor/ProjectAuditorTests.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Unity.ProjectAuditor.EditorTests
 {
-    class ProjectAuditorTests
+    class ProjectAuditorTests : TestFixtureBase
     {
         [Test]
         public void ProjectAuditor_IsInstantiated()
@@ -105,6 +105,29 @@ namespace Unity.ProjectAuditor.EditorTests
 
             Assert.AreEqual(1, numModules);
             Assert.NotNull(projectReport);
+        }
+
+        [Test]
+        public void ProjectAuditor_Report_IsUpdated()
+        {
+            var projectAuditor = new Unity.ProjectAuditor.Editor.ProjectAuditor(m_Config);
+            var report = projectAuditor.Audit(new ProjectAuditorParams
+            {
+                categories = new[] { IssueCategory.ProjectSetting}
+            });
+            Assert.Positive(report.GetIssues(IssueCategory.ProjectSetting).Count);
+
+            report.ClearIssues(IssueCategory.ProjectSetting);
+
+            Assert.Zero(report.GetIssues(IssueCategory.ProjectSetting).Count);
+
+            projectAuditor.Audit(new ProjectAuditorParams
+            {
+                categories = new[] { IssueCategory.ProjectSetting},
+                existingReport = report
+            });
+
+            Assert.Positive(report.GetIssues(IssueCategory.ProjectSetting).Count);
         }
     }
 }


### PR DESCRIPTION
**Problem statement**
1. From the ProjectReport object it's not possible to know whether a certain module/category was analyzed. We can only check the number of reported issues associated to a category. Basically, if a category has zero issues we don't know whether the category was actually analyzed vs no issues were found.
2. To update an existing report, the user must manipulate the ProjectReport object since this is not supported.
**Solution**
- Add information to the report so it's possible to know which categories were analyzed
- Add built-in support for updating an existing report.
