### PR TITLE
Report issue when StreamingAssets on mobile are at 50mb or more

### DIFF
--- a/Editor/Modules/AssetsModule.cs
+++ b/Editor/Modules/AssetsModule.cs
@@ -74,9 +74,9 @@ namespace Unity.ProjectAuditor.Editor.Modules
         {
             var issues = new List<ProjectIssue>();
             AnalyzeResources(issues);
-            
-            if (projectAuditorParams.platform == BuildTarget.Android || projectAuditorParams.platform == BuildTarget.iOS)
-                Mobile_AnalyzeStreamingAssets(issues);
+
+            if (k_StreamingAssetsFolderDescriptor.platforms.Contains(projectAuditorParams.platform.ToString()))
+                AnalyzeStreamingAssets(issues);
 
             if (issues.Any())
                 projectAuditorParams.onIncomingIssues(issues);
@@ -110,7 +110,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             }
         }
 
-        static void Mobile_AnalyzeStreamingAssets(IList<ProjectIssue> issues)
+        static void AnalyzeStreamingAssets(IList<ProjectIssue> issues)
         {
             if (Directory.Exists("Assets/StreamingAssets"))
             {

--- a/Tests/Editor/MobileAssetTests.cs
+++ b/Tests/Editor/MobileAssetTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using NUnit.Framework;
+using Unity.ProjectAuditor.Editor;
+using UnityEditor;
+using UnityEditor.TestTools;
+using UnityEngine;
+
+namespace Unity.ProjectAuditor.EditorTests
+{
+    class MobileAssetTests : TestFixtureBase
+    {
+        const string k_TextureName = "VeryLargeTextureTest60Mb.tga";
+        string m_RelativeTexturePath;
+        bool m_DeleteStreamingAssetsFolder;
+
+        public void CreateTemporaryStreamingAssets()
+        {
+            var texture = new Texture2D(4096, 4096);
+            texture.SetPixel(0, 0, Random.ColorHSV());
+            texture.name = k_TextureName;
+            texture.Apply();
+
+            var encodedTGA = texture.EncodeToTGA();
+
+            m_RelativeTexturePath = Path.Combine("Assets", Path.Combine("StreamingAssets", k_TextureName)).Replace("\\", "/");
+
+            var newDirectoryPath = Path.GetDirectoryName(m_RelativeTexturePath);
+
+            if (!Directory.Exists(newDirectoryPath))
+            {
+                Directory.CreateDirectory(newDirectoryPath);
+                m_DeleteStreamingAssetsFolder = true;
+            }
+
+            File.WriteAllBytes(m_RelativeTexturePath, encodedTGA);
+
+            Assert.True(File.Exists(m_RelativeTexturePath));
+        }
+
+        public void RemoveTemporaryStreamingAssets()
+        {
+            File.Delete(m_RelativeTexturePath);
+
+            if (m_DeleteStreamingAssetsFolder)
+            {
+                Directory.Delete(Path.GetDirectoryName(m_RelativeTexturePath));
+            }
+        }
+
+        [Test]
+        [RequirePlatformSupport(BuildTarget.Android)]
+        public void Android_StreamingAssetsFolderTooLarge_IsReported()
+        {
+            CreateTemporaryStreamingAssets();
+
+            var textureDiagnostic = Analyze(IssueCategory.AssetDiagnostic, issue => issue.descriptor.id == "PAA0001");
+
+            RemoveTemporaryStreamingAssets();
+
+            Assert.IsNotEmpty(textureDiagnostic);
+        }
+
+        [Test]
+        [RequirePlatformSupport(BuildTarget.iOS)]
+        public void iOS_StreamingAssetsFolderTooLarge_IsReported()
+        {
+            CreateTemporaryStreamingAssets();
+
+            var textureDiagnostic = Analyze(IssueCategory.AssetDiagnostic, issue => issue.descriptor.id == "PAA0001");
+
+            RemoveTemporaryStreamingAssets();
+
+            Assert.IsNotEmpty(textureDiagnostic);
+        }
+    }
+}

--- a/Tests/Editor/MobileAssetTests.cs.meta
+++ b/Tests/Editor/MobileAssetTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 782d485c60c2453998bbf8cf90e01e8b
+timeCreated: 1667340219


### PR DESCRIPTION
Changes:

- analysis runs as part of AssetsModule on Android and iOS
- unit test is in one method per platform using RequirePlatformSupport attribute

Detail:  The unit tests rely on fact that .tga file is around 60mb uncompressed size