### PR TITLE
Analyzers for mesh/texture isReadable flag and mesh 32bit format

### DIFF
--- a/Documentation~/Diagnostics.md
+++ b/Documentation~/Diagnostics.md
@@ -12,6 +12,7 @@ Note that there are different ranges within both Code and Settings diagnostic ID
   - `PAS0xxx`: Unity settings 
   - `PAS1xxx`: other settings IDs defined in code rather than in the json
   - `PAT0xxx`: texture related settings
+  - `PAM0xxx`: mesh related settings
 
 # Settings Diagnostics
 This is a full list of all builtin settings diagnostics:
@@ -53,3 +54,6 @@ This is a full list of all builtin settings diagnostics:
 | PAS1002 | Camera Lit Shader Mode Forward and Deferred | HDRP      | Any                      |
 | PAT0000 | Texture: Mip Maps not enabled               | Graphics  | Any                      |
 | PAT0001 | Texture: Mip Maps enabled on 2D texture     | Graphics  | Any                      |
+| PAT0002 | Texture: Read/Write enabled                 | Graphics  | Any                      |
+| PAM0000 | Mesh: Read/Write enabled                    | Graphics  | Any                      |
+| PAM0001 | Mesh: Index Format is 32 bits               | Graphics  | Any                      |

--- a/Editor/MeshAnalyzer.cs
+++ b/Editor/MeshAnalyzer.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.IO;
+using Unity.ProjectAuditor.Editor.Core;
+using Unity.ProjectAuditor.Editor.Diagnostic;
+using Unity.ProjectAuditor.Editor.Modules;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.ProjectAuditor.Editor
+{
+    public class MeshAnalyzer : IMeshModuleAnalyzer
+    {
+        internal static readonly Descriptor k_MeshReadWriteEnabledDescriptor = new Descriptor(
+            "PAM0000",
+            "Mesh: Read/Write enabled",
+            Area.Memory,
+            "Mesh's Read/Write flag is enabled. This causes the mesh data to be duplicated in memory." +
+            "\n\nEnabling Read/Write access may be needed if this mesh is read or written to at run-time, e.g. if used as a MeshCollider or a BlendShape. Polybrush meshes may set this by default, so again save to disable if not modified at run-time." +
+            "\n\nRefer to the 'Mesh.isReadable' documentation for more details on cases when this should stay enabled.",
+            "Select the asset and disable <b>Model</b> import settings <b>Read/Write Enabled</b> option, then click the <b>Apply</b> button."
+        )
+        {
+            messageFormat = "Mesh '{0}' Read/Write is enabled",
+            documentationUrl = "https://docs.unity3d.com/ScriptReference/Mesh-isReadable.html"
+        };
+
+        internal static readonly Descriptor k_Mesh23BitIndexFormatUsedDescriptor = new Descriptor(
+            "PAM0001",
+            "Mesh: Index Format is 32 bits",
+            Area.Memory,
+            "Mesh's 32 bits Index Format is selected. This increases the mesh size and may not work on certain mobile devices.",
+            "Select the asset and set the <b>Model</b> import settings <b>Index Format</b> option to the value <b>16 bits</b>."
+        )
+        {
+            messageFormat = "Mesh '{0}' Index Format is 32 bits",
+            documentationUrl = "https://docs.unity3d.com/ScriptReference/Mesh-indexFormat.html"
+        };
+
+        public void Initialize(ProjectAuditorModule module)
+        {
+            module.RegisterDescriptor(k_MeshReadWriteEnabledDescriptor);
+            module.RegisterDescriptor(k_Mesh23BitIndexFormatUsedDescriptor);
+        }
+
+        public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, ModelImporter modelImporter)
+        {
+            var assetPath = modelImporter.assetPath;
+            var meshName = Path.GetFileNameWithoutExtension(assetPath);
+
+            var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(modelImporter.assetPath);
+
+            if (mesh.isReadable)
+            {
+                yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_MeshReadWriteEnabledDescriptor, meshName)
+                    .WithLocation(modelImporter.assetPath);;
+            }
+
+            if (modelImporter.indexFormat == ModelImporterIndexFormat.UInt32 && mesh.vertexCount <= 65535)
+            {
+                yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_Mesh23BitIndexFormatUsedDescriptor, meshName)
+                    .WithLocation(modelImporter.assetPath);;
+            }
+        }
+    }
+}

--- a/Editor/MeshAnalyzer.cs
+++ b/Editor/MeshAnalyzer.cs
@@ -52,13 +52,13 @@ namespace Unity.ProjectAuditor.Editor
             if (mesh.isReadable)
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_MeshReadWriteEnabledDescriptor, meshName)
-                    .WithLocation(modelImporter.assetPath);;
+                    .WithLocation(modelImporter.assetPath);
             }
 
             if (modelImporter.indexFormat == ModelImporterIndexFormat.UInt32 && mesh.vertexCount <= 65535)
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_Mesh23BitIndexFormatUsedDescriptor, meshName)
-                    .WithLocation(modelImporter.assetPath);;
+                    .WithLocation(modelImporter.assetPath);
             }
         }
     }

--- a/Editor/MeshAnalyzer.cs.meta
+++ b/Editor/MeshAnalyzer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4c65bd5a64fd4111b8e5361ef18a6208
+timeCreated: 1666906844

--- a/Editor/TextureAnalyzer.cs
+++ b/Editor/TextureAnalyzer.cs
@@ -31,19 +31,34 @@ namespace Unity.ProjectAuditor.Editor
             messageFormat = "Texture '{0}' mip maps are enabled"
         };
 
+        internal static readonly Descriptor k_TextureReadWriteEnabledDescriptor = new Descriptor(
+            "PAT0002",
+            "Texture: Read/Write enabled",
+            Area.Memory,
+            "Mesh's Read/Write flag is enabled. This causes the texture data to be duplicated in memory." +
+            "\n\nEnabling Read/Write access may be needed if this mesh is read or written to at run-time." +
+            "\n\nRefer to the 'Texture.isReadable' documentation for more details on cases when this should stay enabled.",
+            "Select the asset and disable import settings <b>Read/Write Enabled</b> option, then click the <b>Apply</b> button."
+        )
+        {
+            messageFormat = "Texture '{0}' Read/Write is enabled",
+            documentationUrl = "https://docs.unity3d.com/ScriptReference/Texture-isReadable.html"
+        };
+
         public void Initialize(ProjectAuditorModule module)
         {
             module.RegisterDescriptor(k_TextureMipMapNotEnabledDescriptor);
             module.RegisterDescriptor(k_TextureMipMapEnabledDescriptor);
+            module.RegisterDescriptor(k_TextureReadWriteEnabledDescriptor);
         }
 
         public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, TextureImporter textureImporter, TextureImporterPlatformSettings textureImporterPlatformSettings)
         {
+            var assetPath = textureImporter.assetPath;
+            var textureName = Path.GetFileNameWithoutExtension(assetPath);
+
             if (textureImporter.mipmapEnabled == false && textureImporter.textureType == TextureImporterType.Default)
             {
-                var assetPath = textureImporter.assetPath;
-                var textureName = Path.GetFileNameWithoutExtension(assetPath);
-
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic,
                     k_TextureMipMapNotEnabledDescriptor, textureName)
                     .WithLocation(assetPath);
@@ -53,12 +68,15 @@ namespace Unity.ProjectAuditor.Editor
                 (textureImporter.textureType == TextureImporterType.Sprite || textureImporter.textureType == TextureImporterType.GUI)
             )
             {
-                var assetPath = textureImporter.assetPath;
-                var textureName = Path.GetFileNameWithoutExtension(assetPath);
-
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic,
                     k_TextureMipMapEnabledDescriptor, textureName)
                     .WithLocation(assetPath);
+            }
+
+            if (textureImporter.isReadable)
+            {
+                yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_TextureReadWriteEnabledDescriptor, textureName)
+                    .WithLocation(textureImporter.assetPath);;
             }
         }
     }

--- a/Tests/Editor/TextureTests.cs
+++ b/Tests/Editor/TextureTests.cs
@@ -15,6 +15,7 @@ namespace Unity.ProjectAuditor.EditorTests
         const string k_TextureNameNoMipMapDefault = k_TextureName + "NoMipMapDefaultTest1234";
         const string k_TextureNameMipMapGUI = k_TextureName + "MipMapGUITest1234";
         const string k_TextureNameMipMapSprite = k_TextureName + "MipMapSpriteTest1234";
+        const string k_TextureNameReadWriteEnabled = k_TextureName + "ReadWriteEnabledTest1234";
 
         const int k_Resolution = 1;
 
@@ -23,6 +24,7 @@ namespace Unity.ProjectAuditor.EditorTests
         TempAsset m_TempTextureNoMipMapDefault;
         TempAsset m_TempTextureMipMapGUI;
         TempAsset m_TempTextureMipMapSprite;
+        TempAsset m_TempTextureReadWriteEnabled;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -62,6 +64,12 @@ namespace Unity.ProjectAuditor.EditorTests
             textureImporter = AssetImporter.GetAtPath(m_TempTextureMipMapSprite.relativePath) as TextureImporter;
             textureImporter.textureType = TextureImporterType.Sprite;
             textureImporter.mipmapEnabled = true;
+            textureImporter.SaveAndReimport();
+
+            m_TempTextureReadWriteEnabled = new TempAsset(k_TextureNameReadWriteEnabled + ".png", encodedPNG);
+
+            textureImporter = AssetImporter.GetAtPath(m_TempTextureReadWriteEnabled.relativePath) as TextureImporter;
+            textureImporter.isReadable = true;
             textureImporter.SaveAndReimport();
         }
 
@@ -125,6 +133,22 @@ namespace Unity.ProjectAuditor.EditorTests
             var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapSprite, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureMipMapEnabledDescriptor));
 
             Assert.NotNull(textureDiagnostic);
+        }
+
+        [Test]
+        public void Texture_ReadWriteEnabled_IsReported()
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureReadWriteEnabled, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureReadWriteEnabledDescriptor));
+
+            Assert.NotNull(textureDiagnostic);
+        }
+
+        [Test]
+        public void Texture_ReadWriteEnabled_IsNotReported()
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureNoMipMapDefault, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureReadWriteEnabledDescriptor));
+
+            Assert.IsNull(textureDiagnostic);
         }
     }
 }


### PR DESCRIPTION
Added some simpler mesh and texture analyzers:
- analyzer to detect Mesh and Texture isReadable import flag (called "Read/Write Enabled" in the importers' UI)
- analyzer to detect Mesh 32bit Index Format for Meshes with less than 65536 vertices (i.e. where this is not needed)
- unit test to test the new texture analyzer
