### PR TITLE
Streaming Assets size diagnostic iteration

### DIFF
--- a/Editor/Modules/AssetsModule.cs
+++ b/Editor/Modules/AssetsModule.cs
@@ -43,7 +43,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
         )
         {
             platforms = new[] {"Android", "iOS"},
-            messageFormat = "StreamingAssets folder contains {0} mb of data",
+            messageFormat = "StreamingAssets folder contains {0} of data",
         };
 
         static readonly long k_StreamingAssetsFolderSizeLimitMb = 50;
@@ -126,7 +126,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 {
                     issues.Add(
                         ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_StreamingAssetsFolderDescriptor,
-                            totalBytes / 1024 / 1024)
+                            Formatting.FormatSize((ulong)totalBytes))
                     );
                 }
             }

--- a/Tests/Editor/MobileAssetTests.cs
+++ b/Tests/Editor/MobileAssetTests.cs
@@ -51,26 +51,36 @@ namespace Unity.ProjectAuditor.EditorTests
         [RequirePlatformSupport(BuildTarget.Android)]
         public void Android_StreamingAssetsFolderTooLarge_IsReported()
         {
+            var platform = m_Platform;
+            m_Platform = BuildTarget.Android;
+
             CreateTemporaryStreamingAssets();
 
-            var textureDiagnostic = Analyze(IssueCategory.AssetDiagnostic, issue => issue.descriptor.id == "PAA0001");
+            var assetDiagnostic = Analyze(IssueCategory.AssetDiagnostic, issue => issue.descriptor.id == "PAA0001");
 
             RemoveTemporaryStreamingAssets();
 
-            Assert.IsNotEmpty(textureDiagnostic);
+            Assert.IsNotEmpty(assetDiagnostic);
+
+            m_Platform = platform;
         }
 
         [Test]
         [RequirePlatformSupport(BuildTarget.iOS)]
         public void iOS_StreamingAssetsFolderTooLarge_IsReported()
         {
+            var platform = m_Platform;
+            m_Platform = BuildTarget.iOS;
+
             CreateTemporaryStreamingAssets();
 
-            var textureDiagnostic = Analyze(IssueCategory.AssetDiagnostic, issue => issue.descriptor.id == "PAA0001");
+            var assetDiagnostic = Analyze(IssueCategory.AssetDiagnostic, issue => issue.descriptor.id == "PAA0001");
 
             RemoveTemporaryStreamingAssets();
 
-            Assert.IsNotEmpty(textureDiagnostic);
+            Assert.IsNotEmpty(assetDiagnostic);
+
+            m_Platform = platform;
         }
     }
 }


### PR DESCRIPTION
Minor iteration to the Streaming Assets size diagnostic:
- make size formatting consistent with other views.
- set test analysis platform 