### PR TITLE
Debug.Log diagnostic iteration

### DIFF
--- a/Editor/InstructionAnalyzers/DebugLogAnalyzer.cs
+++ b/Editor/InstructionAnalyzers/DebugLogAnalyzer.cs
@@ -6,11 +6,14 @@ using Unity.ProjectAuditor.Editor.CodeAnalysis;
 using Unity.ProjectAuditor.Editor.Core;
 using Unity.ProjectAuditor.Editor.Diagnostic;
 using Unity.ProjectAuditor.Editor.Modules;
+using UnityEngine;
 
 namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
 {
     class DebugLogAnalyzer : ICodeModuleInstructionAnalyzer
     {
+        static readonly int k_ModuleHashCode = "UnityEngine.CoreModule.dll".GetHashCode();
+        static readonly int k_TypeHashCode = "UnityEngine.Debug".GetHashCode();
         static readonly int k_ConditionalAttributeHashCode = "System.Diagnostics.ConditionalAttribute".GetHashCode();
 
         static readonly Descriptor k_DebugLogIssueDescriptor = new Descriptor
@@ -55,11 +58,28 @@ namespace Unity.ProjectAuditor.Editor.InstructionAnalyzers
         {
             var callee = (MethodReference)inst.Operand;
             var methodName = callee.Name;
-
             var declaringType = callee.DeclaringType;
 
-            if (!MonoCecilHelper.IsOrInheritedFrom(declaringType, "UnityEngine.Debug"))
+            if (k_TypeHashCode != declaringType.FullName.GetHashCode())
                 return null;
+
+            // second check on module name which requires resolving the type
+            try
+            {
+                var typeDefinition = declaringType.Resolve();
+                if (typeDefinition == null)
+                {
+                    Debug.LogWarning(declaringType.FullName + " could not be resolved.");
+                    return null;
+                }
+
+                if (k_ModuleHashCode != typeDefinition.Module.Name.GetHashCode())
+                    return null;
+            }
+            catch (AssemblyResolutionException e)
+            {
+                Debug.LogWarningFormat("Could not resolve {0}: {1}", declaringType.Name, e.Message);
+            }
 
             // If we find the ConditionalAttribute, we assume this is intended to be compiled out on release
             if (methodDefinition.HasCustomAttributes && methodDefinition.CustomAttributes.Any(a =>


### PR DESCRIPTION
**Problem**
Null ref exception described here: https://github.com/Unity-Technologies/ProjectAuditor/issues/142

**Solution**
This is a fix that checks if the `typeDefinition` is null.

In addition
- Replaced the string comparison with a hash code one.
- Added check on module to make sure `Debug.Log` belongs to `UnityEngine`