### PR TITLE
Fixed tests that broke when detecting new issues

### DIFF
--- a/Tests/Editor/CodeAnalysis/PropertyUsageTests.cs
+++ b/Tests/Editor/CodeAnalysis/PropertyUsageTests.cs
@@ -85,8 +85,10 @@ class UxmlAttributeDescriptionPropertyUsage
         {
             var issues = AnalyzeAndFindAssetIssues(m_TempAssetObjectName);
 
-            Assert.AreEqual(3, issues.Length);
-            Assert.True(issues.All(i => i.description.Equals("'UnityEngine.Object.name' usage")));
+            var propertyNameIssues = issues.Where(i => i.descriptor.id == "PAC0231").ToArray();
+
+            Assert.AreEqual(3, propertyNameIssues.Length);
+            Assert.True(propertyNameIssues.All(i => i.description.Equals("'UnityEngine.Object.name' usage")));
         }
 
         [Test]
@@ -94,7 +96,11 @@ class UxmlAttributeDescriptionPropertyUsage
         {
             var issues = AnalyzeAndFindAssetIssues(m_TempAssetBaseTypePropertyUsage);
 
-            Assert.AreEqual(6, issues.Length);
+            var propertyOfBaseTypeIssues = issues.Where(
+                i => i.descriptor.id == "PAC0039" || i.descriptor.id == "PAC0084" || i.descriptor.id == "PAC0085")
+                .ToArray();
+
+            Assert.AreEqual(6, propertyOfBaseTypeIssues.Length);
         }
 
 #if UNITY_2019_1_OR_NEWER
@@ -103,8 +109,10 @@ class UxmlAttributeDescriptionPropertyUsage
         {
             var issues = AnalyzeAndFindAssetIssues(m_TempAssetUxmlAttributeDescriptionPropertyUsage);
 
-            Assert.AreEqual(1, issues.Length);
-            Assert.AreEqual("'UnityEngine.UIElements.UxmlAttributeDescription.obsoleteNames' usage", issues[0].description);
+            var propertyUxmlAttributeIssues = issues.Where(i => i.descriptor.id == "PAC0191").ToArray();
+
+            Assert.AreEqual(1, propertyUxmlAttributeIssues.Length);
+            Assert.AreEqual("'UnityEngine.UIElements.UxmlAttributeDescription.obsoleteNames' usage", propertyUxmlAttributeIssues[0].description);
         }
 
 #endif

--- a/Tests/Editor/RuleTests.cs
+++ b/Tests/Editor/RuleTests.cs
@@ -58,9 +58,11 @@ namespace Unity.ProjectAuditor.EditorTests
         {
             var issues = AnalyzeAndFindAssetIssues(m_TempAsset);
 
-            Assert.AreEqual(1, issues.Count());
+            var allCamerasIssues = issues.Where(i => i.descriptor.id == "PAC0066").ToArray();
 
-            var issue = issues.FirstOrDefault();
+            Assert.AreEqual(1, allCamerasIssues.Count());
+
+            var issue = allCamerasIssues.FirstOrDefault();
 
             m_Config.ClearAllRules();
 
@@ -101,8 +103,12 @@ namespace Unity.ProjectAuditor.EditorTests
             // retry after domain reload
             var issues = AnalyzeAndFindAssetIssues(m_TempAsset);
 
-            var callingMethod = issues[0].GetContext();
-            var action = m_SerializedConfig.GetAction(issues[0].descriptor, callingMethod);
+            var allCamerasIssues = issues.Where(i => i.descriptor.id == "PAC0066").ToArray();
+
+            Assert.AreEqual(1, allCamerasIssues.Count());
+
+            var callingMethod = allCamerasIssues[0].GetContext();
+            var action = m_SerializedConfig.GetAction(allCamerasIssues[0].descriptor, callingMethod);
 
             // issue has been muted so it should not be reported
             Assert.AreEqual(Severity.None, action);

--- a/Tests/Editor/TextFilterTests.cs
+++ b/Tests/Editor/TextFilterTests.cs
@@ -120,7 +120,7 @@ class InternalClass
                 searchString = "FilterTests.cs"
             };
             var filteredIssues = issues.Where(i => stringFilter.Match(i));
-            Assert.AreEqual(1, filteredIssues.Count());
+            Assert.IsTrue(filteredIssues.Count() >= 1);
         }
 
         [Test]
@@ -146,7 +146,7 @@ class InternalClass
             stringFilter.searchDependencies = true;
 
             filteredIssues = issues.Where(i => stringFilter.Match(i));
-            Assert.AreEqual(1, filteredIssues.Count());
+            Assert.IsTrue(filteredIssues.Count() >= 1);
         }
     }
 }


### PR DESCRIPTION
Mostly fixed unit tests by querying a specific issue (descriptor id).

The fixed TextFilterTests now just check against one or more found issues - not just exactly one - to stay consistent with what the test originally wants to test (if any issues where found related to a cs file name or class name match).