### PR TITLE
Add texture fixers

### DIFF
--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -103,7 +103,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             if (textureImporter.isReadable)
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_TextureReadWriteEnabledDescriptor, textureName)
-                    .WithLocation(textureImporter.assetPath);;
+                    .WithLocation(textureImporter.assetPath);
             }
         }
     }

--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -17,7 +17,16 @@ namespace Unity.ProjectAuditor.Editor.Modules
             "Select the texture asset and, if applicable, enable texture importer option <b>Advanced / Generate Mip Maps</b>."
         )
         {
-            messageFormat = "Texture '{0}' mip maps are not enabled"
+            messageFormat = "Texture '{0}' mip maps are not enabled",
+            fixer = (issue) =>
+            {
+                var textureImporter = AssetImporter.GetAtPath(issue.relativePath) as TextureImporter;
+                if (textureImporter != null)
+                {
+                    textureImporter.mipmapEnabled = true;
+                    textureImporter.SaveAndReimport();
+                }
+            }
         };
 
         internal static readonly Descriptor k_TextureMipMapEnabledDescriptor = new Descriptor(
@@ -28,7 +37,16 @@ namespace Unity.ProjectAuditor.Editor.Modules
             "Select the texture asset and, if applicable, disable texture importer option <b>Advanced / Generate Mip Maps</b>."
         )
         {
-            messageFormat = "Texture '{0}' mip maps are enabled"
+            messageFormat = "Texture '{0}' mip maps are enabled",
+            fixer = (issue) =>
+            {
+                var textureImporter = AssetImporter.GetAtPath(issue.relativePath) as TextureImporter;
+                if (textureImporter != null)
+                {
+                    textureImporter.mipmapEnabled = false;
+                    textureImporter.SaveAndReimport();
+                }
+            }
         };
 
         internal static readonly Descriptor k_TextureReadWriteEnabledDescriptor = new Descriptor(
@@ -42,7 +60,16 @@ namespace Unity.ProjectAuditor.Editor.Modules
         )
         {
             messageFormat = "Texture '{0}' Read/Write is enabled",
-            documentationUrl = "https://docs.unity3d.com/ScriptReference/Texture-isReadable.html"
+            documentationUrl = "https://docs.unity3d.com/ScriptReference/Texture-isReadable.html",
+            fixer = (issue) =>
+            {
+                var textureImporter = AssetImporter.GetAtPath(issue.relativePath) as TextureImporter;
+                if (textureImporter != null)
+                {
+                    textureImporter.isReadable = false;
+                    textureImporter.SaveAndReimport();
+                }
+            }
         };
 
         public void Initialize(ProjectAuditorModule module)

--- a/Tests/Editor/TextureTests.cs
+++ b/Tests/Editor/TextureTests.cs
@@ -125,14 +125,30 @@ namespace Unity.ProjectAuditor.EditorTests
             var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapGUI, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureMipMapEnabledDescriptor));
 
             Assert.NotNull(textureDiagnostic);
+            Assert.NotNull(textureDiagnostic.descriptor);
+            Assert.NotNull(textureDiagnostic.descriptor.fixer);
+
+            textureDiagnostic.descriptor.Fix(textureDiagnostic);
+
+            textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapGUI, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureMipMapEnabledDescriptor));
+
+            Assert.Null(textureDiagnostic);
         }
 
         [Test]
-        public void Texture_MipMapUsedForSprite_IsReported()
+        public void Texture_MipMapUsedForSprite_IsReportedAndFixed()
         {
             var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapSprite, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureMipMapEnabledDescriptor));
 
             Assert.NotNull(textureDiagnostic);
+            Assert.NotNull(textureDiagnostic.descriptor);
+            Assert.NotNull(textureDiagnostic.descriptor.fixer);
+
+            textureDiagnostic.descriptor.Fix(textureDiagnostic);
+
+            textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureMipMapSprite, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureMipMapEnabledDescriptor));
+
+            Assert.Null(textureDiagnostic);
         }
 
         [Test]
@@ -141,6 +157,14 @@ namespace Unity.ProjectAuditor.EditorTests
             var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureReadWriteEnabled, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureReadWriteEnabledDescriptor));
 
             Assert.NotNull(textureDiagnostic);
+            Assert.NotNull(textureDiagnostic.descriptor);
+            Assert.NotNull(textureDiagnostic.descriptor.fixer);
+
+            textureDiagnostic.descriptor.Fix(textureDiagnostic);
+
+            textureDiagnostic = AnalyzeAndFindAssetIssues(m_TempTextureReadWriteEnabled, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureReadWriteEnabledDescriptor));
+
+            Assert.Null(textureDiagnostic);
         }
 
         [Test]


### PR DESCRIPTION
Diagnostics may come with a "Fixers". This change adds auto-fixing support to the built-in texture diagnostics.