### PR TITLE
Excluding gcIncremental test when lower than 2019.1

### DIFF
--- a/Data/ProjectSettings.json
+++ b/Data/ProjectSettings.json
@@ -327,7 +327,8 @@
             "value": "False",
             "areas": ["CPU"],
             "description": "The Incremental Garbage Collection feature is disabled. This might lead to CPU spikes due to Garbage Collection.",
-            "solution": "To enable this feature, enable option <b>Project Settings ➔ Player ➔ Other Settings ➔ Configuration ➔ Use incremental GC</b>. Note this is not a substitute for reducing per-frame managed allocations."
+            "solution": "To enable this feature, enable option <b>Project Settings ➔ Player ➔ Other Settings ➔ Configuration ➔ Use incremental GC</b>. Note this is not a substitute for reducing per-frame managed allocations.",
+            "minimumVersion": "2019.1"
         }
     ]
 }


### PR DESCRIPTION
The PlayerSettings.gcIncremental symbol was introduced on Unity 2019.1.

Updated the PlayerSettings.json entry for that issue and symbol to require minimum 2019.1.