### PR TITLE
Meshmodule and analyzer fixes

### DIFF
--- a/Editor/Modules/IMeshModuleAnalyzer.cs
+++ b/Editor/Modules/IMeshModuleAnalyzer.cs
@@ -8,6 +8,6 @@ namespace Unity.ProjectAuditor.Editor.Modules
     {
         void Initialize(ProjectAuditorModule module);
 
-        IEnumerable<ProjectIssue> Analyze(BuildTarget platform, ModelImporter modelImporter);
+        IEnumerable<ProjectIssue> Analyze(BuildTarget platform, AssetImporter assetImporter);
     }
 }

--- a/Editor/Modules/MeshAnalyzer.cs
+++ b/Editor/Modules/MeshAnalyzer.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using Unity.ProjectAuditor.Editor.Core;
 using Unity.ProjectAuditor.Editor.Diagnostic;
-using Unity.ProjectAuditor.Editor.Modules;
 using UnityEditor;
 using UnityEngine;
 
@@ -42,23 +41,24 @@ namespace Unity.ProjectAuditor.Editor.Modules
             module.RegisterDescriptor(k_Mesh23BitIndexFormatUsedDescriptor);
         }
 
-        public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, ModelImporter modelImporter)
+        public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, AssetImporter assetImporter)
         {
-            var assetPath = modelImporter.assetPath;
+            var assetPath = assetImporter.assetPath;
             var meshName = Path.GetFileNameWithoutExtension(assetPath);
 
-            var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(modelImporter.assetPath);
+            var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(assetPath);
 
             if (mesh.isReadable)
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_MeshReadWriteEnabledDescriptor, meshName)
-                    .WithLocation(modelImporter.assetPath);
+                    .WithLocation(assetPath);
             }
 
-            if (modelImporter.indexFormat == ModelImporterIndexFormat.UInt32 && mesh.vertexCount <= 65535)
+            var modelImporter = assetImporter as ModelImporter;
+            if (modelImporter != null && modelImporter.indexFormat == ModelImporterIndexFormat.UInt32 && mesh.vertexCount <= 65535)
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_Mesh23BitIndexFormatUsedDescriptor, meshName)
-                    .WithLocation(modelImporter.assetPath);
+                    .WithLocation(assetPath);
             }
         }
     }

--- a/Editor/Modules/MeshAnalyzer.cs
+++ b/Editor/Modules/MeshAnalyzer.cs
@@ -23,7 +23,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             documentationUrl = "https://docs.unity3d.com/ScriptReference/Mesh-isReadable.html"
         };
 
-        internal static readonly Descriptor k_Mesh23BitIndexFormatUsedDescriptor = new Descriptor(
+        internal static readonly Descriptor k_Mesh32BitIndexFormatUsedDescriptor = new Descriptor(
             "PAM0001",
             "Mesh: Index Format is 32 bits",
             Area.Memory,
@@ -38,7 +38,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
         public void Initialize(ProjectAuditorModule module)
         {
             module.RegisterDescriptor(k_MeshReadWriteEnabledDescriptor);
-            module.RegisterDescriptor(k_Mesh23BitIndexFormatUsedDescriptor);
+            module.RegisterDescriptor(k_Mesh32BitIndexFormatUsedDescriptor);
         }
 
         public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, AssetImporter assetImporter)
@@ -63,7 +63,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     mesh.vertexCount <= 65535)
                 {
                     yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic,
-                        k_Mesh23BitIndexFormatUsedDescriptor, mesh.name)
+                        k_Mesh32BitIndexFormatUsedDescriptor, mesh.name)
                         .WithLocation(assetPath);
                 }
             }

--- a/Editor/Modules/MeshAnalyzer.cs
+++ b/Editor/Modules/MeshAnalyzer.cs
@@ -44,21 +44,28 @@ namespace Unity.ProjectAuditor.Editor.Modules
         public IEnumerable<ProjectIssue> Analyze(BuildTarget platform, AssetImporter assetImporter)
         {
             var assetPath = assetImporter.assetPath;
-            var meshName = Path.GetFileNameWithoutExtension(assetPath);
+            var subAssets = AssetDatabase.LoadAllAssetsAtPath(assetPath);
 
-            var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(assetPath);
-
-            if (mesh.isReadable)
+            foreach (var subAsset in subAssets)
             {
-                yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_MeshReadWriteEnabledDescriptor, meshName)
-                    .WithLocation(assetPath);
-            }
+                var mesh = subAsset as Mesh;
+                if (mesh == null)
+                    continue;
 
-            var modelImporter = assetImporter as ModelImporter;
-            if (modelImporter != null && modelImporter.indexFormat == ModelImporterIndexFormat.UInt32 && mesh.vertexCount <= 65535)
-            {
-                yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_Mesh23BitIndexFormatUsedDescriptor, meshName)
-                    .WithLocation(assetPath);
+                if (mesh.isReadable)
+                {
+                    yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_MeshReadWriteEnabledDescriptor, mesh.name)
+                        .WithLocation(assetPath);
+                }
+
+                var modelImporter = assetImporter as ModelImporter;
+                if (modelImporter != null && modelImporter.indexFormat == ModelImporterIndexFormat.UInt32 &&
+                    mesh.vertexCount <= 65535)
+                {
+                    yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic,
+                        k_Mesh23BitIndexFormatUsedDescriptor, mesh.name)
+                        .WithLocation(assetPath);
+                }
             }
         }
     }

--- a/Editor/Modules/MeshModule.cs
+++ b/Editor/Modules/MeshModule.cs
@@ -75,22 +75,32 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 var importer = AssetImporter.GetAtPath(pathToMesh);
                 var modelImporter = importer as ModelImporter;
 
-                var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(pathToMesh);
-                var size = Profiler.GetRuntimeMemorySizeLong(mesh);
+                var subAssets = AssetDatabase.LoadAllAssetsAtPath(pathToMesh);
 
-                var issue = ProjectIssue.Create(k_MeshIssueLayout.category, mesh.name)
-                    .WithCustomProperties(
-                        new object[((int)MeshProperty.Num)]
-                        {
-                            mesh.vertexCount,
-                            mesh.triangles.Length / 3,
-                            modelImporter != null ? modelImporter.meshCompression : ModelImporterMeshCompression.Off,
-                            size,
-                            currentPlatform
-                        })
-                    .WithLocation(new Location(pathToMesh));
+                foreach (var subAsset in subAssets)
+                {
+                    var mesh = subAsset as Mesh;
+                    if (mesh == null)
+                        continue;
 
-                issues.Add(issue);
+                    var size = Profiler.GetRuntimeMemorySizeLong(mesh);
+
+                    var issue = ProjectIssue.Create(k_MeshIssueLayout.category, mesh.name)
+                        .WithCustomProperties(
+                            new object[((int)MeshProperty.Num)]
+                            {
+                                mesh.vertexCount,
+                                mesh.triangles.Length / 3,
+                                modelImporter != null
+                                ? modelImporter.meshCompression
+                                : ModelImporterMeshCompression.Off,
+                                size,
+                                currentPlatform
+                            })
+                        .WithLocation(new Location(pathToMesh));
+
+                    issues.Add(issue);
+                }
 
                 foreach (var analyzer in m_Analyzers)
                 {

--- a/Editor/Modules/MeshModule.cs
+++ b/Editor/Modules/MeshModule.cs
@@ -71,11 +71,9 @@ namespace Unity.ProjectAuditor.Editor.Modules
             foreach (var guid in allMeshes)
             {
                 var pathToMesh = AssetDatabase.GUIDToAssetPath(guid);
-                var modelImporter = AssetImporter.GetAtPath(pathToMesh) as ModelImporter;
-                if (modelImporter == null)
-                {
-                    continue;
-                }
+
+                var importer = AssetImporter.GetAtPath(pathToMesh);
+                var modelImporter = importer as ModelImporter;
 
                 var mesh = AssetDatabase.LoadAssetAtPath<Mesh>(pathToMesh);
                 var size = Profiler.GetRuntimeMemorySizeLong(mesh);
@@ -86,7 +84,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                         {
                             mesh.vertexCount,
                             mesh.triangles.Length / 3,
-                            modelImporter.meshCompression,
+                            modelImporter != null ? modelImporter.meshCompression : ModelImporterMeshCompression.Off,
                             size,
                             currentPlatform
                         })
@@ -96,7 +94,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
                 foreach (var analyzer in m_Analyzers)
                 {
-                    var platformDiagnostics = analyzer.Analyze(currentPlatform, modelImporter).ToArray();
+                    var platformDiagnostics = analyzer.Analyze(currentPlatform, importer).ToArray();
 
                     issues.AddRange(platformDiagnostics);
                 }

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -55,7 +55,7 @@ namespace Unity.ProjectAuditor.Editor
 
     public sealed class ProjectAuditor : UnityEditor.Build.IOrderedCallback, UnityEditor.Build.IPreprocessBuildWithReport
     {
-        public const string PackageId = @"com.unity.project-auditor";
+        public const string PackageName = @"com.unity.project-auditor";
         public const string PackagePath = @"Packages/com.unity.project-auditor";
         public int callbackOrder { get; }
         public ProjectAuditorConfig config { get; }
@@ -504,7 +504,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
     public interface IMeshModuleAnalyzer
     {
-        public System.Collections.Generic.IEnumerable<ProjectIssue> Analyze(UnityEditor.BuildTarget platform, UnityEditor.ModelImporter modelImporter);
+        public System.Collections.Generic.IEnumerable<ProjectIssue> Analyze(UnityEditor.BuildTarget platform, UnityEditor.AssetImporter assetImporter);
         public void Initialize(Unity.ProjectAuditor.Editor.Core.ProjectAuditorModule module);
     }
 
@@ -523,7 +523,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
     public class MeshAnalyzer : IMeshModuleAnalyzer
     {
         public MeshAnalyzer() {}
-        public System.Collections.Generic.IEnumerable<ProjectIssue> Analyze(UnityEditor.BuildTarget platform, UnityEditor.ModelImporter modelImporter);
+        public System.Collections.Generic.IEnumerable<ProjectIssue> Analyze(UnityEditor.BuildTarget platform, UnityEditor.AssetImporter assetImporter);
         public void Initialize(Unity.ProjectAuditor.Editor.Core.ProjectAuditorModule module);
     }
 


### PR DESCRIPTION
This change contains two corrections to the Mesh Module / Analyzers:

1. Pure mesh assets (not Models):  The code covers an asset type that just contains one mesh and doesn't use the ModelImporter. Typically file type ".mesh" or ".asset" where the user created or duplicated a single mesh.

Details:  This could be a procedural mesh written to a file or a duplicated subasset mesh (duplication as a Editor user action implicitly creates a file with extension ".mesh" to store a single mesh in). Those mesh assets don't use the ModelImporter, thus there is no compression to report or other available advanced mesh asset import settings.

2. Now subassets are being iterated over so we analyze all subasset meshes within e.g. an imported .fbx.