### PR TITLE
Texture compression analyzers

### DIFF
--- a/Editor/Utils/PlayerSettingsUtil.cs
+++ b/Editor/Utils/PlayerSettingsUtil.cs
@@ -64,5 +64,24 @@ namespace Unity.ProjectAuditor.Editor.Utils
             method.Invoke(null, args);
             return (int)args[1] > 0;
         }
+
+#if UNITY_2021_2_OR_NEWER
+        public static void GetDefaultTextureCompressionFormat(BuildTargetGroup buildTargetGroup, out int formatEnumIndex, out Array formatEnumValues)
+        {
+            formatEnumValues = default;
+            formatEnumIndex = -1;
+
+            var method = typeof(PlayerSettings).GetMethod("GetDefaultTextureCompressionFormat",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            if (method == null)
+                throw new NotSupportedException("PlayerSettings.GetDefaultTextureCompressionFormat method is not supported");
+
+            var format = method.Invoke(null, new object[] { buildTargetGroup });
+
+            var enumType = format.GetType();
+            formatEnumValues = Enum.GetValues(enumType);
+            formatEnumIndex = (int)format;
+        }
+#endif
     }
 }

--- a/Editor/Utils/Unity.ProjectAuditor.Editor.Utils.api
+++ b/Editor/Utils/Unity.ProjectAuditor.Editor.Utils.api
@@ -51,6 +51,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
 
     public static class PlayerSettingsUtil
     {
+        public static void GetDefaultTextureCompressionFormat(UnityEditor.BuildTargetGroup buildTargetGroup, out int formatEnumIndex, out System.Array formatEnumValues);
         public static int GetVertexChannelCompressionMask();
         public static bool IsStaticBatchingEnabled(UnityEditor.BuildTarget platform);
         public static void SetVertexChannelCompressionMask(int newValue);


### PR DESCRIPTION
Added PlayerSettingsUtils.GetDefaultTextureCompressionFormat() to fetch this new setting in 2021.2+ Unity versions via reflection.