### PR TITLE
Add 'FindObjectOfType' usage detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+* Added _UnityEngine.Object.FindObjectOfType_ usage detection
+
 ## [0.9.0-preview] - 2022-12-01
 * Added diagnostic area _Quality_, _Support_ and _Requirement_
 * Added _documentation_ support to descriptor

--- a/Data/ApiDatabase.json
+++ b/Data/ApiDatabase.json
@@ -777,8 +777,8 @@
             "id": "PAC0129",
             "type": "UnityEngine.Object",
             "method": "FindObjectsOfType",
-            "areas": ["Memory"],
-            "description": "<b>Object.FindObjectsOfType()</b> allocates managed memory.",
+            "areas": ["CPU", "Memory"],
+            "description": "<b>Object.FindObjectsOfType()</b> allocates managed memory and can be slow.",
             "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         },
         {
@@ -1489,6 +1489,14 @@
           "platforms": ["WebGL"],
           "description": "The <b>UnityEngine.Microphone</b> API is not supported on this platform. Using Microphone might lead to build/runtime errors.",
           "solution": "Do not use the Microphone API on this platform."
+        },
+        {
+          "id": "PAC0234",
+          "type": "UnityEngine.Object",
+          "method": "FindObjectOfType",
+          "areas": ["CPU", "Memory"],
+          "description": "<b>Object.FindObjectOfType()</b> allocates managed memory and can be slow.",
+          "solution": "Try to avoid calling this method in frequently-updated code. Ideally, this method should only be used during initialisation, and the results should be cached if they need to be re-used."
         }
     ]
 }

--- a/Tests/Editor/CodeAnalysis/FindObjectsOfTypeTests.cs
+++ b/Tests/Editor/CodeAnalysis/FindObjectsOfTypeTests.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace Unity.ProjectAuditor.EditorTests
+{
+    class FindObjectsOfTypeTests : TestFixtureBase
+    {
+        TempAsset m_TempAsset;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            m_TempAsset = new TempAsset("FindObjectsOfTypeClass.cs", @"
+using UnityEngine;
+
+class FindObjectsOfTypeClass
+{
+    void TestMethod()
+    {
+        // FindObjectsOfType
+        UnityEngine.Object.FindObjectsOfType<Collider>();
+        UnityEngine.GameObject.FindObjectsOfType<Collider>();
+
+        UnityEngine.Object.FindObjectsOfType(typeof(Collider));
+        UnityEngine.GameObject.FindObjectsOfType(typeof(Collider));
+
+        // FindObjectOfType
+        UnityEngine.Object.FindObjectOfType<Collider>();
+        UnityEngine.GameObject.FindObjectOfType<Collider>();
+
+        UnityEngine.Object.FindObjectOfType(typeof(Collider));
+        UnityEngine.GameObject.FindObjectOfType(typeof(Collider));
+    }
+}
+");
+        }
+
+        [Test]
+        public void CodeAnalysis_FindObjectsOfType_IsReported()
+        {
+            var issues = AnalyzeAndFindAssetIssues(m_TempAsset);
+
+            Assert.AreEqual(4, issues.Count(i => i.descriptor.id == "PAC0129"));
+        }
+
+        [Test]
+        public void CodeAnalysis_FindObjectOfType_IsReported()
+        {
+            var issues = AnalyzeAndFindAssetIssues(m_TempAsset);
+
+            Assert.AreEqual(4, issues.Count(i => i.descriptor.id == "PAC0234"));
+        }
+    }
+}

--- a/Tests/Editor/CodeAnalysis/FindObjectsOfTypeTests.cs.meta
+++ b/Tests/Editor/CodeAnalysis/FindObjectsOfTypeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd8d39717f4c99949a127e73ebf5166d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
`Object.FindObjectOfType` is implemented by calling `FindObjectsOfType`, however, it is not reported as a potential issue.

### Changes made
Added `FindObjectOfType` usage detection and improve test coverage.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
