### PR TITLE
Fix: handle unnamed pass parsing in Unity 2021.2.14+

### DIFF
--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -725,8 +725,10 @@ namespace Unity.ProjectAuditor.Editor.Modules
             var passMatch = cv.pass.Equals(passName);
             if (!passMatch)
             {
-                var isUnnamed = k_NoPassNames.Contains(cv.pass);
-#if UNITY_2019_1_OR_NEWER
+                var isUnnamed = k_NoPassNames.Contains(cv.pass) || cv.pass.StartsWith("<Unnamed Pass ");
+#if UNITY_2021_3_OR_NEWER || UNITY_2021_2_14 || UNITY_2021_2_15 || UNITY_2021_2_16 || UNITY_2021_2_17 || UNITY_2021_2_18 || UNITY_2021_2_19
+                passMatch = isUnnamed && string.IsNullOrEmpty(passName);
+#elif UNITY_2019_1_OR_NEWER
                 var pass = 0;
                 passMatch = isUnnamed && passName.StartsWith(k_UnnamedPassPrefix) && int.TryParse(passName.Substring(k_UnnamedPassPrefix.Length), out pass);
 #else


### PR DESCRIPTION
### Description

Fixes #159 

### Changes made

Check for unnamed pass formatting specific to Unity 2021.2.14+

### Notes

Haven't checked what formatting Editor.log and Player.log uses in Unity 2022 and 2023.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
