### PR TITLE
Create new setting option

### DIFF
--- a/Editor/ProjectAuditorSettingsProvider.cs
+++ b/Editor/ProjectAuditorSettingsProvider.cs
@@ -67,22 +67,14 @@ namespace Unity.ProjectAuditor.Editor
 
         public IEnumerable<ProjectAuditorSettings> GetSettings()
         {
+            RefreshAssets();
+
             yield return m_DefaultSettings;
 
-            bool hasMissingAsset = false;
             foreach (var settingsAsset in m_SettingsAssets)
             {
-                if (settingsAsset == null)
-                {
-                    hasMissingAsset = true;
-                    continue;
-                }
-
                 yield return settingsAsset;
             }
-
-            if (hasMissingAsset)
-                RefreshAssets();
         }
 
         /// <summary>

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1070,21 +1070,16 @@ namespace Unity.ProjectAuditor.Editor.UI
 
             if (GUILayout.Button(Contents.NewSettingsButton, GUILayout.Width(180), GUILayout.Height(18)))
             {
-                var path = EditorUtility.SaveFilePanel(
-                    "Create New Settings...",
-                    Path.Combine(Application.dataPath, "Editor"),
+                var relativePath = EditorUtility.SaveFilePanelInProject("Create New Settings...",
                     "ProjectAuditorSettings-" + m_Platform,
-                    "asset");
+                    "asset",
+                    "Please select the new settings file location",
+                    Path.Combine(Application.dataPath, "Editor"));
 
-                if (path != string.Empty)
+                if (relativePath != string.Empty)
                 {
-                    if (path.StartsWith(Application.dataPath))
-                    {
-                        path = "Assets" + path.Substring(Application.dataPath.Length);
-                    }
-
                     var newSettings = CreateInstance<ProjectAuditorSettings>();
-                    AssetDatabase.CreateAsset(newSettings, path);
+                    AssetDatabase.CreateAsset(newSettings, relativePath);
                     m_SettingsProvider.SelectCurrentSettings(newSettings);
 
                     Selection.activeObject = newSettings;

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1071,7 +1071,7 @@ namespace Unity.ProjectAuditor.Editor.UI
             if (GUILayout.Button(Contents.NewSettingsButton, GUILayout.Width(180), GUILayout.Height(18)))
             {
                 var path = EditorUtility.SaveFilePanel(
-                    "New Setting...",
+                    "Create New Settings...",
                     Path.Combine(Application.dataPath, "Editor"),
                     "ProjectAuditorSettings-" + m_Platform,
                     "asset");

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1046,7 +1046,7 @@ namespace Unity.ProjectAuditor.Editor.UI
         {
             EditorGUILayout.BeginHorizontal();
 
-            EditorGUILayout.LabelField(new GUIContent(Contents.SettingsTitle), GUILayout.Width(EditorGUIUtility.labelWidth - 1));
+            EditorGUILayout.LabelField(Contents.SettingsTitle, GUILayout.Width(EditorGUIUtility.labelWidth - 1));
 
             var dropdownRect = GUILayoutUtility.GetLastRect();
             dropdownRect.x += EditorGUIUtility.labelWidth + 2;
@@ -1066,6 +1066,29 @@ namespace Unity.ProjectAuditor.Editor.UI
                 }
 
                 menu.DropDown(dropdownRect);
+            }
+
+            if (GUILayout.Button(Contents.NewSettingsButton, GUILayout.Width(180), GUILayout.Height(18)))
+            {
+                var path = EditorUtility.SaveFilePanel(
+                    "New Setting...",
+                    Path.Combine(Application.dataPath, "Editor"),
+                    "ProjectAuditorSettings-" + m_Platform,
+                    "asset");
+
+                if (path != string.Empty)
+                {
+                    if (path.StartsWith(Application.dataPath))
+                    {
+                        path = "Assets" + path.Substring(Application.dataPath.Length);
+                    }
+
+                    var newSettings = CreateInstance<ProjectAuditorSettings>();
+                    AssetDatabase.CreateAsset(newSettings, path);
+                    m_SettingsProvider.SelectCurrentSettings(newSettings);
+
+                    Selection.activeObject = newSettings;
+                }
             }
 
             EditorGUILayout.EndHorizontal();
@@ -1377,6 +1400,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                 new GUIContent("Platform", "Select the target platform.");
 
             public static readonly GUIContent SettingsTitle = new GUIContent("Settings");
+            public static readonly GUIContent NewSettingsButton = new GUIContent("Create New Settings");
 
 #if UNITY_2019_1_OR_NEWER
             public static readonly GUIContent SaveButton = Utility.GetIcon(Utility.IconType.Save, "Save current report to json file");


### PR DESCRIPTION
### Description

Added an option on the first welcome layout of PA.

### Changes made

- ProjectAuditorWindow has a new "Create New Settings" button with a layout on the right of the settings drop-down
- the "Create New Settings" button action uses the standard save file prompt, saves a new ProjectSettings asset if the requester was not cancelled
- creating a new settings asset selects this asset both as the current PA setting and as the current selected asset in the Editor, i.e. the Inspector (if open/visible) shows the settings right away to the user

### Notes

TODO: I could update the docs regarding the settings in this PR, unless we prefer a full pass over the docs at a later time.
