### PR TITLE
Variants platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Fixed names of build-generated assets in Build Report
 * Fixed parsing of unnamed shader passes in Unity 2021.2.14+
 * Fixed AudioSettings speaker mode diagnostic
+* Fixed reporting of variants if not compiled for analysis platform
 
 ## [0.9.0-preview] - 2022-12-01
 * Added diagnostic area _Quality_, _Support_ and _Requirement_

--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -80,6 +80,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
         public string[] platformKeywords;
         public ShaderRequirements[] requirements;
         public GraphicsTier graphicsTier;
+        public BuildTarget buildTarget;
         public ShaderCompilerPlatform compilerPlatform;
     }
 
@@ -89,6 +90,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
         public string[] keywords;
         public string[] platformKeywords;
         public GraphicsTier graphicsTier;
+        public BuildTarget buildTarget;
         public ShaderCompilerPlatform compilerPlatform;
     }
 
@@ -248,7 +250,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             var shaderPathMap = CollectShaders();
             ProcessShaders(projectAuditorParams.platform, shaderPathMap, projectAuditorParams.onIncomingIssues);
 
-            ProcessComputeShaders(projectAuditorParams.onIncomingIssues);
+            ProcessComputeShaders(projectAuditorParams.platform, projectAuditorParams.onIncomingIssues);
 
             // clear collected variants before next build
             ClearBuildData();
@@ -368,11 +370,11 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 }
 #endif
                 onIncomingIssues(ProcessShader(shader, assetPath, assetSize, alwaysIncludedShaders.Contains(shader)));
-                onIncomingIssues(ProcessVariants(shader, assetPath));
+                onIncomingIssues(ProcessVariants(platform, shader, assetPath));
             }
         }
 
-        void ProcessComputeShaders(Action<IEnumerable<ProjectIssue>> onIncomingIssues)
+        void ProcessComputeShaders(BuildTarget platform, Action<IEnumerable<ProjectIssue>> onIncomingIssues)
         {
 #if COMPUTE_SHADER_ANALYSIS
             var issues = new List<ProjectIssue>();
@@ -382,6 +384,9 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 var computeShaderName = shaderCompilerData.Key.name;
                 foreach (var shaderVariantData in shaderCompilerData.Value)
                 {
+                    if (shaderVariantData.buildTarget != platform)
+                        continue;
+
                     issues.Add(ProjectIssue.Create(k_ComputeShaderVariantLayout.category, computeShaderName)
                         .WithCustomProperties(new object[(int)ComputeShaderVariantProperty.Num]
                         {
@@ -486,7 +491,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             }
         }
 
-        IEnumerable<ProjectIssue> ProcessVariants(Shader shader, string assetPath)
+        IEnumerable<ProjectIssue> ProcessVariants(BuildTarget platform, Shader shader, string assetPath)
         {
             if (s_ShaderVariantData.ContainsKey(shader))
             {
@@ -494,6 +499,9 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
                 foreach (var shaderVariantData in shaderVariants)
                 {
+                    if (shaderVariantData.buildTarget != platform)
+                        continue;
+
                     yield return ProjectIssue.Create(IssueCategory.ShaderVariant, shader.name)
                         .WithLocation(assetPath)
                         .WithCustomProperties(new object[(int)ShaderVariantProperty.Num]
@@ -551,6 +559,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     keywords = GetShaderKeywords(shader, shaderCompilerData.shaderKeywordSet.GetShaderKeywords()),
                     platformKeywords = PlatformKeywordSetToStrings(shaderCompilerData.platformKeywordSet),
                     graphicsTier = shaderCompilerData.graphicsTier,
+                    buildTarget = shaderCompilerData.buildTarget,
                     compilerPlatform = shaderCompilerData.shaderCompilerPlatform
                 });
             }
@@ -588,6 +597,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     platformKeywords = PlatformKeywordSetToStrings(shaderCompilerData.platformKeywordSet),
                     requirements = shaderRequirementsList.ToArray(),
                     graphicsTier = shaderCompilerData.graphicsTier,
+                    buildTarget = shaderCompilerData.buildTarget,
                     compilerPlatform = shaderCompilerData.shaderCompilerPlatform
                 });
             }

--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -384,8 +384,10 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 var computeShaderName = shaderCompilerData.Key.name;
                 foreach (var shaderVariantData in shaderCompilerData.Value)
                 {
+#if UNITY_2020_3_OR_NEWER
                     if (shaderVariantData.buildTarget != platform)
                         continue;
+#endif
 
                     issues.Add(ProjectIssue.Create(k_ComputeShaderVariantLayout.category, computeShaderName)
                         .WithCustomProperties(new object[(int)ComputeShaderVariantProperty.Num]
@@ -499,8 +501,10 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
                 foreach (var shaderVariantData in shaderVariants)
                 {
+#if UNITY_2020_3_OR_NEWER
                     if (shaderVariantData.buildTarget != platform)
                         continue;
+#endif
 
                     yield return ProjectIssue.Create(IssueCategory.ShaderVariant, shader.name)
                         .WithLocation(assetPath)
@@ -559,7 +563,9 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     keywords = GetShaderKeywords(shader, shaderCompilerData.shaderKeywordSet.GetShaderKeywords()),
                     platformKeywords = PlatformKeywordSetToStrings(shaderCompilerData.platformKeywordSet),
                     graphicsTier = shaderCompilerData.graphicsTier,
+#if UNITY_2020_3_OR_NEWER
                     buildTarget = shaderCompilerData.buildTarget,
+#endif
                     compilerPlatform = shaderCompilerData.shaderCompilerPlatform
                 });
             }
@@ -597,7 +603,9 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     platformKeywords = PlatformKeywordSetToStrings(shaderCompilerData.platformKeywordSet),
                     requirements = shaderRequirementsList.ToArray(),
                     graphicsTier = shaderCompilerData.graphicsTier,
+#if UNITY_2020_3_OR_NEWER
                     buildTarget = shaderCompilerData.buildTarget,
+#endif
                     compilerPlatform = shaderCompilerData.shaderCompilerPlatform
                 });
             }


### PR DESCRIPTION
### Description

Restrict variants processing to current analysis platform.

### Changes made

Changed ShadersModule to ignore shader and compute variants if not compiled current analysis platform.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
