### PR TITLE
Backwards compatibility fixes

### DIFF
--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -385,10 +385,8 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 var computeShaderName = shaderCompilerData.Key.name;
                 foreach (var shaderVariantData in shaderCompilerData.Value)
                 {
-#if UNITY_2020_3_OR_NEWER
-                    if (shaderVariantData.buildTarget != platform)
+                    if (shaderVariantData.buildTarget != BuildTarget.NoTarget && shaderVariantData.buildTarget != platform)
                         continue;
-#endif
 
                     issues.Add(ProjectIssue.Create(k_ComputeShaderVariantLayout.category, computeShaderName)
                         .WithCustomProperties(new object[(int)ComputeShaderVariantProperty.Num]
@@ -502,10 +500,8 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
                 foreach (var shaderVariantData in shaderVariants)
                 {
-#if UNITY_2020_3_OR_NEWER
-                    if (shaderVariantData.buildTarget != platform)
+                    if (shaderVariantData.buildTarget != BuildTarget.NoTarget && shaderVariantData.buildTarget != platform)
                         continue;
-#endif
 
                     yield return ProjectIssue.Create(IssueCategory.ShaderVariant, shader.name)
                         .WithLocation(assetPath)

--- a/Editor/Modules/ShadersModule.cs
+++ b/Editor/Modules/ShadersModule.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Unity.ProjectAuditor.Editor.Core;
 using Unity.ProjectAuditor.Editor.Diagnostic;
 using Unity.ProjectAuditor.Editor.Utils;
@@ -555,6 +556,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 s_ComputeShaderVariantData.Add(shader, new List<ComputeShaderVariantData>());
             }
 
+            var buildTargetPropertyInfo = typeof(ShaderCompilerData).GetRuntimeProperty("buildTarget");
             foreach (var shaderCompilerData in data)
             {
                 s_ComputeShaderVariantData[shader].Add(new ComputeShaderVariantData
@@ -563,9 +565,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     keywords = GetShaderKeywords(shader, shaderCompilerData.shaderKeywordSet.GetShaderKeywords()),
                     platformKeywords = PlatformKeywordSetToStrings(shaderCompilerData.platformKeywordSet),
                     graphicsTier = shaderCompilerData.graphicsTier,
-#if UNITY_2020_3_OR_NEWER
-                    buildTarget = shaderCompilerData.buildTarget,
-#endif
+                    buildTarget = (buildTargetPropertyInfo != null) ? (BuildTarget)buildTargetPropertyInfo.GetValue(shaderCompilerData) : BuildTarget.NoTarget,
                     compilerPlatform = shaderCompilerData.shaderCompilerPlatform
                 });
             }
@@ -583,6 +583,8 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 s_ShaderVariantData.Add(shader, new List<ShaderVariantData>());
             }
 
+            // the buildTarget property is only available as of 2020_3_35 so we need to use reflection to get the value
+            var buildTargetPropertyInfo = typeof(ShaderCompilerData).GetRuntimeProperty("buildTarget");
             foreach (var shaderCompilerData in data)
             {
                 var shaderRequirements = shaderCompilerData.shaderRequirements;
@@ -603,9 +605,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     platformKeywords = PlatformKeywordSetToStrings(shaderCompilerData.platformKeywordSet),
                     requirements = shaderRequirementsList.ToArray(),
                     graphicsTier = shaderCompilerData.graphicsTier,
-#if UNITY_2020_3_OR_NEWER
-                    buildTarget = shaderCompilerData.buildTarget,
-#endif
+                    buildTarget = (buildTargetPropertyInfo != null) ? (BuildTarget)buildTargetPropertyInfo.GetValue(shaderCompilerData) : BuildTarget.NoTarget,
                     compilerPlatform = shaderCompilerData.shaderCompilerPlatform
                 });
             }

--- a/Editor/UI/Framework/SharedStyles.cs
+++ b/Editor/UI/Framework/SharedStyles.cs
@@ -137,9 +137,8 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
             {
                 if (s_TitleLabel == null)
                 {
-                    s_TitleLabel = new GUIStyle(EditorStyles.label);
-                    s_TitleLabel.fontSize += 14;
-                    s_TitleLabel.fontStyle = FontStyle.Bold;
+                    s_TitleLabel = new GUIStyle(EditorStyles.boldLabel);
+                    s_TitleLabel.fontSize = 26;
                     s_TitleLabel.fixedHeight = 34;
                 }
                 return s_TitleLabel;
@@ -152,9 +151,9 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
             {
                 if (s_LargeLabel == null)
                 {
-                    s_LargeLabel = new GUIStyle(EditorStyles.label);
-                    s_LargeLabel.fontSize += 2;
-                    s_LargeLabel.fontStyle = FontStyle.Bold;
+                    s_LargeLabel = new GUIStyle(EditorStyles.boldLabel);
+                    s_LargeLabel.fontSize = 14;
+                    s_LargeLabel.fixedHeight = 22;
                 }
                 return s_LargeLabel;
             }

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1467,7 +1467,7 @@ namespace Unity.ProjectAuditor.Editor.UI
 @"
 Project Auditor is an experimental static analysis tool that analyzes assets, settings, and scripts of the Unity project and produces a report that contains the following:
 
- •  <b>Code and Settings Diagnostics</b>: a list of possible problems that might affect performance, memory and other areas.
+ •  <b>Diagnostics</b>: a list of possible problems that might affect performance, memory and other areas.
  •  <b>BuildReport</b>: timing and size information of the last build.
  •  <b>Assets information</b>
 

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1010,15 +1010,18 @@ namespace Unity.ProjectAuditor.Editor.UI
 
             EditorGUILayout.LabelField(Contents.WelcomeTextTitle, SharedStyles.TitleLabel);
 
-            EditorGUILayout.Space(10);
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
 
             EditorGUILayout.LabelField(Contents.WelcomeText, SharedStyles.TextAreaWithDynamicSize);
 
-            EditorGUILayout.Space(12);
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
 
             DrawHorizontalLine();
 
-            EditorGUILayout.Space(16);
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
 
             EditorGUILayout.LabelField(Contents.ConfigurationsTitle, SharedStyles.LargeLabel);
 


### PR DESCRIPTION
### Description

Fix several compilation issues in Unity 2018

### Notes

- In 2018
  - `GUIStyle.fontSize` is 0 as opposed to 12 in new versions.
  - `EditorGUILayout.Space` does not take any parameters.
- `ShaderCompilerData.buildTarget` has been added recently and backported to older versions of Unity so we have to use Reflection to see if it's available.