### PR TITLE
Add Percentage formatting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+* Added percentage formatting support
+* Added individual asset size percentage to Build Report
+
 ## [0.9.2-preview] - 2023-02-07
 * Added Fog shader variant stripping analyzer
 * Add IL2CPP Compiler Configuration analyzer

--- a/Editor/Core/PropertyDefinition.cs
+++ b/Editor/Core/PropertyDefinition.cs
@@ -42,7 +42,8 @@ namespace Unity.ProjectAuditor.Editor.Core
         Integer,
         ULong,
         Bytes,
-        Time
+        Time,
+        Percentage
     }
 
     public struct PropertyDefinition

--- a/Editor/Modules/BuildReportModule.cs
+++ b/Editor/Modules/BuildReportModule.cs
@@ -191,7 +191,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                             assetImporter != null ? assetImporter.GetType().FullName : k_Unknown,
                             content.type,
                             content.packedSize,
-                            Math.Round(content.packedSize / (double)dataSize, 2),
+                            Math.Round((double)content.packedSize / dataSize, 4),
                             packedAsset.shortPath
                         });
                 }

--- a/Editor/Modules/BuildReportModule.cs
+++ b/Editor/Modules/BuildReportModule.cs
@@ -24,6 +24,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
         ImporterType = 0,
         RuntimeType,
         Size,
+        SizePercent,
         BuildFile,
         Num
     }
@@ -73,6 +74,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(BuildReportFileProperty.ImporterType), format = PropertyFormat.String, name = "Importer Type"},
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(BuildReportFileProperty.RuntimeType), format = PropertyFormat.String, name = "Runtime Type", defaultGroup = true},
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(BuildReportFileProperty.Size), format = PropertyFormat.Bytes, name = "Size", longName = "Size in the Build"},
+                new PropertyDefinition { type = PropertyTypeUtil.FromCustom(BuildReportFileProperty.SizePercent), format = PropertyFormat.Percentage, name = "Size % (of Data)", longName = "Percentage of the total data size"},
                 new PropertyDefinition { type = PropertyType.Path, name = "Path", hidden = true},
                 new PropertyDefinition { type = PropertyTypeUtil.FromCustom(BuildReportFileProperty.BuildFile), format = PropertyFormat.String, name = "Build File"}
             }
@@ -170,6 +172,8 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
         IEnumerable<ProjectIssue> AnalyzePackedAssets(BuildReport buildReport)
         {
+            var dataSize = buildReport.packedAssets.SelectMany(p => p.contents).Sum(c => (long)c.packedSize);
+
             foreach (var packedAsset in buildReport.packedAssets)
             {
                 // note that there can be several entries for each source asset (for example, a prefab can reference a Texture, a Material and a shader)
@@ -187,6 +191,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                             assetImporter != null ? assetImporter.GetType().FullName : k_Unknown,
                             content.type,
                             content.packedSize,
+                            Math.Round(content.packedSize / (double)dataSize, 2),
                             packedAsset.shortPath
                         });
                 }

--- a/Editor/UI/Framework/AnalysisView.cs
+++ b/Editor/UI/Framework/AnalysisView.cs
@@ -498,7 +498,8 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
             var columns = m_Table.multiColumnHeader.state.columns;
             for (int i = 0; i < m_Layout.properties.Length; i++)
             {
-                columns[i].width = m_Layout.properties[i].hidden ? 0 : EditorPrefs.GetFloat(GetPrefKey(k_ColumnSizeKey + i), columns[i].width);
+                // when reloading we need to make sure visible columns have a width >= minWidth
+                columns[i].width = m_Layout.properties[i].hidden ? 0 : Math.Max(columns[i].minWidth, EditorPrefs.GetFloat(GetPrefKey(k_ColumnSizeKey + i), columns[i].width));
             }
 
             var defaultGroupPropertyIndex = m_Layout.defaultGroupPropertyIndex;

--- a/Editor/UI/Framework/IssueTable.cs
+++ b/Editor/UI/Framework/IssueTable.cs
@@ -251,7 +251,7 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                 else if (PropertyTypeUtil.IsCustom(property.type))
                 {
                     var customPropertyIndex = PropertyTypeUtil.ToCustomIndex(propertyType);
-                    if (property.format == PropertyFormat.Bytes || property.format == PropertyFormat.Time)
+                    if (property.format == PropertyFormat.Bytes || property.format == PropertyFormat.Time || property.format == PropertyFormat.Percentage)
                     {
                         string label;
                         if (property.format == PropertyFormat.Bytes)
@@ -275,7 +275,7 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                                 var value = issueTableItem.ProjectIssue.GetCustomPropertyFloat(customPropertyIndex);
                                 sum += value;
                             }
-                            label = Formatting.FormatTime(sum);
+                            label = property.format == PropertyFormat.Time ? Formatting.FormatTime(sum) : Formatting.FormatPercentage(sum);
                         }
 
                         GUI.enabled = false;
@@ -377,6 +377,9 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
                                         EditorGUI.LabelField(cellRect, Utility.GetIcon(Utility.IconType.Info, intAsString), labelStyle);
                                     else
                                         EditorGUI.LabelField(cellRect, new GUIContent(intAsString, intAsString), labelStyle);
+                                    break;
+                                case PropertyFormat.Percentage:
+                                    EditorGUI.LabelField(cellRect, Formatting.FormatPercentage(issue.GetCustomPropertyFloat(customPropertyIndex)), labelStyle);
                                     break;
                                 default:
                                     var value = issue.GetCustomProperty(customPropertyIndex);

--- a/Editor/Unity.ProjectAuditor.Editor.api
+++ b/Editor/Unity.ProjectAuditor.Editor.api
@@ -378,6 +378,7 @@ namespace Unity.ProjectAuditor.Editor.Core
         Bool = 1,
         Bytes = 4,
         Integer = 2,
+        Percentage = 6,
         String = 0,
         Time = 5,
         ULong = 3,
@@ -506,11 +507,12 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
     public enum BuildReportFileProperty
     {
-        BuildFile = 3,
+        BuildFile = 4,
         ImporterType = 0,
-        Num = 4,
+        Num = 5,
         RuntimeType = 1,
         Size = 2,
+        SizePercent = 3,
     }
 
     public enum BuildReportMetaData

--- a/Editor/Utils/Formatting.cs
+++ b/Editor/Utils/Formatting.cs
@@ -32,6 +32,11 @@ namespace Unity.ProjectAuditor.Editor.Utils
             return FormatTime(TimeSpan.FromMilliseconds(timeMs));
         }
 
+        /// <summary>
+        /// Formats a decimal number as a percentage with one decimal place.
+        /// </summary>
+        /// <param name="number">The decimal number to format.</param>
+        /// <returns>A string representation of the decimal number as a percentage.</returns>
         public static string FormatPercentage(float number)
         {
             return $"{number:P1}";

--- a/Editor/Utils/Formatting.cs
+++ b/Editor/Utils/Formatting.cs
@@ -32,6 +32,11 @@ namespace Unity.ProjectAuditor.Editor.Utils
             return FormatTime(TimeSpan.FromMilliseconds(timeMs));
         }
 
+        public static string FormatPercentage(float number)
+        {
+            return $"{number:P1}";
+        }
+
         public static string FormatSize(ulong size)
         {
             return EditorUtility.FormatBytes((long)size);

--- a/Editor/Utils/Unity.ProjectAuditor.Editor.Utils.api
+++ b/Editor/Utils/Unity.ProjectAuditor.Editor.Utils.api
@@ -8,7 +8,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
         public static string CombineStrings(string[] strings, string separator = default(string));
         public static string FormatDateTime(System.DateTime dateTime);
         public static string FormatDuration(System.TimeSpan t);
-        public static string FormatPercentage(float percentage);
+        public static string FormatPercentage(float number);
         public static string FormatSize(System.UInt64 size);
         public static string FormatTime(float timeMs);
         public static string FormatTime(System.TimeSpan timeSpan);

--- a/Editor/Utils/Unity.ProjectAuditor.Editor.Utils.api
+++ b/Editor/Utils/Unity.ProjectAuditor.Editor.Utils.api
@@ -8,6 +8,7 @@ namespace Unity.ProjectAuditor.Editor.Utils
         public static string CombineStrings(string[] strings, string separator = default(string));
         public static string FormatDateTime(System.DateTime dateTime);
         public static string FormatDuration(System.TimeSpan t);
+        public static string FormatPercentage(float percentage);
         public static string FormatSize(System.UInt64 size);
         public static string FormatTime(float timeMs);
         public static string FormatTime(System.TimeSpan timeSpan);

--- a/Tests/Editor/FormattingTests.cs
+++ b/Tests/Editor/FormattingTests.cs
@@ -40,5 +40,14 @@ namespace Unity.ProjectAuditor.EditorTests
 
             Assert.AreEqual(formatted, Formatting.FormatTime(time));
         }
+
+        [TestCase(0.12345f, "12.3 %")]
+        [TestCase(0.5f, "50.0 %")]
+        [TestCase(0.0f, "0.0 %")]
+        [TestCase(1.0f, "100.0 %")]
+        public void Formatting_Percentage_IsFormatted(float number, string expectedResult)
+        {
+            Assert.AreEqual(expectedResult, Formatting.FormatPercentage(number));
+        }
     }
 }


### PR DESCRIPTION
### Description

- Add Percentage formatting support
- Use Percentage formatting to display asset data size

![size-percentage](https://user-images.githubusercontent.com/12098182/217828031-1cf0270a-fba9-480b-a1a4-20b50c77b544.PNG)


### Changes made

- Added Percentage formatting support and test coverage
- Updated Build Report module to display asset data size is percentage

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [x] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
