### PR TITLE
Improve switching view UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+* Fixed View switching cancellation
+
 ## [0.9.3-preview.1] - 2023-02-14
 * Added percentage formatting support
 * Added individual asset size percentage to Build Report

--- a/Editor/UI/ProjectAuditorWindow.cs
+++ b/Editor/UI/ProjectAuditorWindow.cs
@@ -1298,7 +1298,7 @@ namespace Unity.ProjectAuditor.Editor.UI
                         if (!m_ProjectReport.HasCategory(category))
                         {
                             var displayName = m_ViewManager.GetView(category).desc.displayName;
-                            if (!EditorUtility.DisplayDialog(k_ProjectAuditorName, $"'{displayName}' analysis will now begin", "Ok", "Cancel"))
+                            if (!EditorUtility.DisplayDialog(k_ProjectAuditorName, $"'{displayName}' analysis will now begin.", "Ok", "Cancel"))
                                 return; // do not analyze and change view
 
                             AuditCategories(new[] {category});


### PR DESCRIPTION
### Description

Improve view switching UX:
- Reword dialog text as per https://github.com/Unity-Technologies/ProjectAuditor/issues/172
- Do not actually change view if user change mind by selecting 'Cancel'

<img width="532" alt="switch-view-dialog" src="https://user-images.githubusercontent.com/12098182/219325672-9eafca9d-86ab-4cf5-86a8-e7085cf25af5.png">

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
