### PR TITLE
Add SRP Asset Settings Analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Added SRP Asset Settings analyzer.
 * Added Shader SRP Batcher analyzer.
 
 ## [0.9.3-preview.3] - 2023-02-28

--- a/Documentation~/Diagnostics.md
+++ b/Documentation~/Diagnostics.md
@@ -57,6 +57,7 @@ This is a full list of all builtin settings diagnostics:
 | PAS1005 | IL2CPP Compiler Debug						| Player    | Any                      |
 | PAS1006 | LightMap Streaming						    | Player    | Any                      |
 | PAS1007 | Texture Streaming Enabled                   | Quality   | Any                      |
+| PAS1008 | SRP Batcher Enabled                         | SRP Asset | Any                      |
 
 
 # Asset Diagnostics

--- a/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs
+++ b/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using Unity.ProjectAuditor.Editor.Core;
+using Unity.ProjectAuditor.Editor.Diagnostic;
+using Unity.ProjectAuditor.Editor.Modules;
+using UnityEngine;
+using UnityEngine.Rendering;
+#if PACKAGE_URP
+using UnityEngine.Rendering.Universal;
+#elif PACKAGE_HDRP
+using System.Reflection;
+using UnityEngine.Rendering.HighDefinition;
+#endif
+
+namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
+{
+    class SrpAssetSettingsAnalyzer : ISettingsModuleAnalyzer
+    {
+        internal const string PAS1008 = nameof(PAS1008);
+
+        static readonly Descriptor k_SRPBatcherSettingDescriptor = new Descriptor(
+            PAS1008,
+            "SRP Asset: SRP Batcher",
+            Area.CPU,
+            "SRP batcher is disabled in Render Pipeline Asset.",
+            "Enable SRP batcher in Render Pipeline Asset. This will reduce the CPU time Unity requires to prepare and dispatch draw calls for materials that use the same shader variant.")
+        {
+            messageFormat = "SRP batcher is disabled in '{0}' in '{1}'",
+            fixer = FixSrpBatcherSetting
+        };
+
+        public void Initialize(ProjectAuditorModule module)
+        {
+            module.RegisterDescriptor(k_SRPBatcherSettingDescriptor);
+        }
+
+        public IEnumerable<ProjectIssue> Analyze(ProjectAuditorParams projectAuditorParams)
+        {
+#if UNITY_2019_3_OR_NEWER
+            IEnumerable<ProjectIssue> issues = Analyze(GraphicsSettings.defaultRenderPipeline, -1);
+            foreach (ProjectIssue issue in issues)
+            {
+                yield return issue;
+            }
+
+            var initialQualityLevel = QualitySettings.GetQualityLevel();
+            for (var i = 0; i < QualitySettings.names.Length; ++i)
+            {
+                QualitySettings.SetQualityLevel(i);
+
+                issues = Analyze(QualitySettings.renderPipeline, i);
+                foreach (ProjectIssue issue in issues)
+                {
+                    yield return issue;
+                }
+            }
+
+            QualitySettings.SetQualityLevel(initialQualityLevel);
+#else
+            yield break;
+#endif
+        }
+
+        private static void FixSrpBatcherSetting(ProjectIssue issue)
+        {
+#if UNITY_2019_3_OR_NEWER
+            int qualityLevel = issue.GetCustomPropertyInt32(0);
+            if (qualityLevel == -1)
+            {
+                FixSrpBatcherSetting(GraphicsSettings.defaultRenderPipeline);
+                return;
+            }
+
+            var initialQualityLevel = QualitySettings.GetQualityLevel();
+            QualitySettings.SetQualityLevel(qualityLevel);
+            FixSrpBatcherSetting(QualitySettings.renderPipeline);
+            QualitySettings.SetQualityLevel(initialQualityLevel);
+#endif
+        }
+
+#if UNITY_2019_3_OR_NEWER
+        private IEnumerable<ProjectIssue> Analyze(RenderPipelineAsset renderPipeline, int qualityLevel)
+        {
+            if (renderPipeline == null) yield break;
+#if PACKAGE_URP
+            if (renderPipeline is UniversalRenderPipelineAsset urpAsset &&
+                !urpAsset.useSRPBatcher)
+            {
+                yield return CreateSrpBatcherIssue(qualityLevel, urpAsset.name);
+            }
+#elif PACKAGE_HDRP
+            FieldInfo enableSrpBatcherField = GetSrpBatcherField(renderPipeline, out HDRenderPipelineAsset hdrpAsset);
+            if (enableSrpBatcherField != null && !(bool)enableSrpBatcherField.GetValue(hdrpAsset))
+            {
+
+                yield return CreateSrpBatcherIssue(qualityLevel, hdrpAsset.name);
+            }
+#endif
+        }
+
+        private static ProjectIssue CreateSrpBatcherIssue(int qualityLevel, string name)
+        {
+            string assetLocation = qualityLevel == -1
+                ? "Default Rendering Pipeline Asset"
+                : $"Rendering Pipeline Asset in Quality Level: {QualitySettings.names[qualityLevel]}";
+            return ProjectIssue.Create(IssueCategory.ProjectSetting, k_SRPBatcherSettingDescriptor,
+                    name, assetLocation)
+                .WithCustomProperties(new object[] { qualityLevel })
+                .WithLocation(qualityLevel == -1 ? "Project/Graphics" : "Project/Quality");
+        }
+
+        internal static void FixSrpBatcherSetting(RenderPipelineAsset renderPipeline, bool value = true)
+        {
+            if (renderPipeline == null) return;
+#if PACKAGE_URP
+            if (renderPipeline is UniversalRenderPipelineAsset urpAsset)
+            {
+                urpAsset.useSRPBatcher = value;
+            }
+#elif PACKAGE_HDRP
+            FieldInfo enableSrpBatcherField = GetSrpBatcherField(renderPipeline,
+                out HDRenderPipelineAsset hdrpAsset);
+            if (enableSrpBatcherField != null)
+            {
+                enableSrpBatcherField.SetValue(hdrpAsset, value);
+            }
+#endif
+        }
+
+#if PACKAGE_HDRP
+        private static FieldInfo GetSrpBatcherField(RenderPipelineAsset renderPipeline,
+            out HDRenderPipelineAsset hdrpAsset)
+        {
+            hdrpAsset = null;
+            if (renderPipeline is HDRenderPipelineAsset asset)
+            {
+                hdrpAsset = asset;
+                return hdrpAsset.GetType()
+                    .GetField("enableSRPBatcher", BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+
+            return null;
+        }
+#endif
+#endif
+    }
+}

--- a/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs
+++ b/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs
@@ -66,13 +66,13 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
             int qualityLevel = issue.GetCustomPropertyInt32(0);
             if (qualityLevel == -1)
             {
-                FixSrpBatcherSetting(GraphicsSettings.defaultRenderPipeline);
+                SetSrpBatcherSetting(GraphicsSettings.defaultRenderPipeline);
                 return;
             }
 
             var initialQualityLevel = QualitySettings.GetQualityLevel();
             QualitySettings.SetQualityLevel(qualityLevel);
-            FixSrpBatcherSetting(QualitySettings.renderPipeline);
+            SetSrpBatcherSetting(QualitySettings.renderPipeline);
             QualitySettings.SetQualityLevel(initialQualityLevel);
 #endif
         }
@@ -108,7 +108,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
                 .WithLocation(qualityLevel == -1 ? "Project/Graphics" : "Project/Quality");
         }
 
-        internal static void FixSrpBatcherSetting(RenderPipelineAsset renderPipeline, bool value = true)
+        internal static void SetSrpBatcherSetting(RenderPipelineAsset renderPipeline, bool value = true)
         {
             if (renderPipeline == null) return;
 #if PACKAGE_URP

--- a/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs.meta
+++ b/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 076e4cee97814a678f82ea678ce247eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Unity.ProjectAuditor.Editor.asmdef
+++ b/Editor/Unity.ProjectAuditor.Editor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "Unity.ProjectAuditor.Editor.Utils",
-        "Unity.RenderPipelines.HighDefinition.Runtime"
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Unity.RenderPipelines.Universal.Runtime"
     ],
     "includePlatforms": [
         "Editor"
@@ -41,6 +42,11 @@
             "name": "com.unity.nuget.mono-cecil",
             "expression": "1.11.4",
             "define": "UNITY_MONO_CECIL_1_11_4_OR_NEWER"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "7.0",
+            "define": "PACKAGE_URP"
         }
     ],
     "noEngineReferences": false

--- a/Tests/Editor/SettingsAnalysisTests.cs
+++ b/Tests/Editor/SettingsAnalysisTests.cs
@@ -560,5 +560,31 @@ namespace Unity.ProjectAuditor.EditorTests
                 QualitySettings.streamingMipmapsActive = values[i];
             }
         }
+
+        [Test]
+#if !UNITY_2019_3_OR_NEWER
+        [Ignore("This requires the new Shader API")]
+#endif
+        public void SrpAssetSettingsAnalysis_SrpBatching_IsNotReportedOnceFixed()
+        {
+#if UNITY_2019_3_OR_NEWER
+            if (GraphicsSettings.defaultRenderPipeline == null)
+            {
+                return;
+            }
+
+            SrpAssetSettingsAnalyzer.FixSrpBatcherSetting(GraphicsSettings.defaultRenderPipeline, false);
+
+            var issues = Analyze(IssueCategory.ProjectSetting, i => i.descriptor.title.Equals("SRP Asset: SRP Batcher"));
+            var srpBatchingIssue = issues.FirstOrDefault();
+            Assert.NotNull(srpBatchingIssue);
+            Assert.IsTrue(srpBatchingIssue.GetCustomPropertyInt32(0) == -1, "Default Render Pipeline should have quality level -1.");
+
+            SrpAssetSettingsAnalyzer.FixSrpBatcherSetting(GraphicsSettings.defaultRenderPipeline);
+
+            issues = Analyze(IssueCategory.ProjectSetting, i => i.descriptor.title.Equals("SRP Asset: SRP Batcher"));
+            Assert.Null(issues.FirstOrDefault());
+#endif
+        }
     }
 }

--- a/Tests/Editor/ShadersAnalysisTests.cs
+++ b/Tests/Editor/ShadersAnalysisTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using Unity.ProjectAuditor.Editor;
@@ -19,8 +17,6 @@ namespace Unity.ProjectAuditor.EditorTests
     class ShadersAnalysisTests : TestFixtureBase
     {
         const string k_ShaderName = "Custom/MyTestShader,1"; // comma in the name for testing purposes
-        const string k_UrpCodeInclude =
-            @"#include ""Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl""";
 
 #pragma warning disable 0414
         TestAsset m_ShaderResource;


### PR DESCRIPTION
### Description

When using SRP, we should report if SRP batcher is disabled in any URP/HDRP asset.

### Screenshot

![Screenshot 2023-03-07 123048](https://user-images.githubusercontent.com/99196672/223412266-bcb9fd51-149f-4fc4-bfe5-5d4e2b4da403.png)

### Changes made

Added SRP Asset Settings analyzer.

### Notes

 This should provide an auto-fixer

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [x] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
