### PR TITLE
Add texture anisotropic level analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 * Added SRP Asset Settings analyzer.
 * Added Shader SRP Batcher analyzer.
+* Added anisotropic texture level analyzer.
 
 ## [0.9.3-preview.3] - 2023-02-28
 * Fixed lines and bars drawing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 * Added SRP Asset Settings analyzer.
 * Added Shader SRP Batcher analyzer.
-* Added anisotropic texture level analyzer.
+* Added texture anisotropic level analyzer.
 
 ## [0.9.3-preview.3] - 2023-02-28
 * Fixed lines and bars drawing

--- a/Documentation~/Diagnostics.md
+++ b/Documentation~/Diagnostics.md
@@ -69,6 +69,7 @@ Builtin asset-specific diagnostics:
 | PAT0001 | Texture: Mipmaps enabled on Sprite/UI texture  | Graphics  | Any                      |
 | PAT0002 | Texture: Read/Write enabled                    | Graphics  | Any                      |
 | PAT0003 | Texture: Streaming Mipmaps not enabled         | Graphics  | Any                      |
+| PAT0004 | Texture: Anisotropic level is more than 1      | Graphics  | Any                      |
 | PAM0000 | Mesh: Read/Write enabled                       | Graphics  | Any                      |
 | PAM0001 | Mesh: Index Format is 32 bits                  | Graphics  | Any                      |
 | PAS0000 | Shader: Not compatible with SRP batcher        | Graphics  | Any                      |

--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -182,7 +182,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
                     .WithLocation(textureImporter.assetPath);
             }
 
-            if (textureImporter.anisoLevel > 1)
+            if (textureImporter.mipmapEnabled && textureImporter.filterMode != FilterMode.Point && textureImporter.anisoLevel > 1)
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_TextureAnisotropicLevelDescriptor, textureName)
                     .WithLocation(textureImporter.assetPath);

--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -99,13 +99,13 @@ namespace Unity.ProjectAuditor.Editor.Modules
 
         internal static readonly Descriptor k_TextureAnisotropicLevelDescriptor = new Descriptor(
             PAT0004,
-            "Texture: Anisotropic level is more than 1",
+            "Texture: Anisotropic level is higher than 1",
             new[] {Area.GPU, Area.Quality},
-            "The anisotropic level is more than 1. Anisotropic filtering makes textures look better when viewed at a shallow angle, but it can be slower to process on the GPU.",
+            "The anisotropic level is higher than 1. Anisotropic filtering makes textures look better when viewed at a shallow angle, but it can be slower to process on the GPU.",
             "Consider setting the anisotropic level to 1."
         )
         {
-            messageFormat = "Texture '{0}' has an anisotropic level of more than 1.",
+            messageFormat = "Texture '{0}' has an anisotropic level higher than 1.",
             fixer = (issue) =>
             {
                 var textureImporter = AssetImporter.GetAtPath(issue.relativePath) as TextureImporter;

--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -101,8 +101,8 @@ namespace Unity.ProjectAuditor.Editor.Modules
             PAT0004,
             "Texture: Anisotropic level is more than 1",
             new[] {Area.GPU, Area.Quality},
-            "The anisotropic texture level is more than 1. Anisotropic filtering makes Textures look better when viewed at a shallow angle, but it can be slower to process on the GPU.",
-            "Consider setting the anisotropic texture level to 1."
+            "The anisotropic level is more than 1. Anisotropic filtering makes textures look better when viewed at a shallow angle, but it can be slower to process on the GPU.",
+            "Consider setting the anisotropic level to 1."
         )
         {
             messageFormat = "Texture '{0}' has an anisotropic level of more than 1.",

--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using Unity.ProjectAuditor.Editor.Core;
 using Unity.ProjectAuditor.Editor.Diagnostic;
-using Unity.ProjectAuditor.Editor.Modules;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Profiling;
@@ -15,6 +14,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
         internal const string PAT0001 = nameof(PAT0001);
         internal const string PAT0002 = nameof(PAT0002);
         internal const string PAT0003 = nameof(PAT0003);
+        internal const string PAT0004 = nameof(PAT0004);
 
         internal static readonly Descriptor k_TextureMipMapNotEnabledDescriptor = new Descriptor(
             PAT0000,
@@ -97,12 +97,33 @@ namespace Unity.ProjectAuditor.Editor.Modules
             }
         };
 
+        internal static readonly Descriptor k_TextureAnisotropicLevelDescriptor = new Descriptor(
+            PAT0004,
+            "Texture: Anisotropic level is more than 1",
+            new[] {Area.GPU, Area.Quality},
+            "The anisotropic texture level is more than 1. Anisotropic filtering makes Textures look better when viewed at a shallow angle, but it can be slower to process on the GPU.",
+            "Consider setting the anisotropic texture level to 1."
+        )
+        {
+            messageFormat = "Texture '{0}' has an anisotropic level of more than 1.",
+            fixer = (issue) =>
+            {
+                var textureImporter = AssetImporter.GetAtPath(issue.relativePath) as TextureImporter;
+                if (textureImporter != null)
+                {
+                    textureImporter.anisoLevel = 1;
+                    textureImporter.SaveAndReimport();
+                }
+            }
+        };
+
         public void Initialize(ProjectAuditorModule module)
         {
             module.RegisterDescriptor(k_TextureMipMapNotEnabledDescriptor);
             module.RegisterDescriptor(k_TextureMipMapEnabledDescriptor);
             module.RegisterDescriptor(k_TextureReadWriteEnabledDescriptor);
             module.RegisterDescriptor(k_TextureStreamingMipMapEnabledDescriptor);
+            module.RegisterDescriptor(k_TextureAnisotropicLevelDescriptor);
         }
 
         public IEnumerable<ProjectIssue> Analyze(ProjectAuditorParams projectAuditorParams, TextureImporter textureImporter, TextureImporterPlatformSettings platformSettings)
@@ -158,6 +179,12 @@ namespace Unity.ProjectAuditor.Editor.Modules
             if (!textureImporter.streamingMipmaps && size > Mathf.Pow(projectAuditorParams.settings.TextureStreamingMipmapsSizeLimit, 2))
             {
                 yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_TextureStreamingMipMapEnabledDescriptor, textureName)
+                    .WithLocation(textureImporter.assetPath);
+            }
+
+            if (textureImporter.anisoLevel > 1)
+            {
+                yield return ProjectIssue.Create(IssueCategory.AssetDiagnostic, k_TextureAnisotropicLevelDescriptor, textureName)
                     .WithLocation(textureImporter.assetPath);
             }
         }

--- a/Tests/Editor/TextureTests.cs
+++ b/Tests/Editor/TextureTests.cs
@@ -111,6 +111,8 @@ namespace Unity.ProjectAuditor.EditorTests
             m_TestTextureAnisotropicLevelOne = new TestAsset(k_TextureNameAnisotropicLevelOne + ".png", encodedPNG);
             textureImporter = AssetImporter.GetAtPath(m_TestTextureAnisotropicLevelOne.relativePath) as TextureImporter;
             textureImporter.anisoLevel = 1;
+            textureImporter.filterMode = FilterMode.Bilinear;
+            textureImporter.mipmapEnabled = true;
             textureImporter.SaveAndReimport();
         }
 
@@ -263,6 +265,25 @@ namespace Unity.ProjectAuditor.EditorTests
             var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TestTextureAnisotropicLevelOne, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureAnisotropicLevelDescriptor));
 
             Assert.IsNull(textureDiagnostic);
+
+            var textureImporter = AssetImporter.GetAtPath(m_TestTextureAnisotropicLevelOne.relativePath) as TextureImporter;
+            textureImporter.anisoLevel = 2;
+            textureImporter.mipmapEnabled = false;
+            textureImporter.SaveAndReimport();
+
+            textureDiagnostic = AnalyzeAndFindAssetIssues(m_TestTextureAnisotropicLevelOne, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureAnisotropicLevelDescriptor));
+            Assert.IsNull(textureDiagnostic);
+
+            textureImporter.mipmapEnabled = true;
+            textureImporter.filterMode = FilterMode.Point;
+            textureImporter.SaveAndReimport();
+
+            textureDiagnostic = AnalyzeAndFindAssetIssues(m_TestTextureAnisotropicLevelOne, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureAnisotropicLevelDescriptor));
+            Assert.IsNull(textureDiagnostic);
+
+            textureImporter.anisoLevel = 1;
+            textureImporter.filterMode = FilterMode.Bilinear;
+            textureImporter.SaveAndReimport();
         }
 
     }

--- a/Tests/Editor/TextureTests.cs
+++ b/Tests/Editor/TextureTests.cs
@@ -19,6 +19,8 @@ namespace Unity.ProjectAuditor.EditorTests
         const string k_TextureNameReadWriteEnabled = k_TextureName + "ReadWriteEnabledTest1234";
         const string k_TextureNameStreamingMipmapDisabled = k_TextureName + "StreamingMipmapTest1234";
         const string k_TextureNameStreamingMipmapEnabled = k_TextureName + "StreamingMipmapOnTest1234";
+        const string k_TextureNameAnisotropicLevelBig = k_TextureName + "AnisotropicLevelBigText1234";
+        const string k_TextureNameAnisotropicLevelOne = k_TextureName + "AnisotropicLevelOneText1234";
 
         const int k_Resolution = 1;
 
@@ -30,6 +32,8 @@ namespace Unity.ProjectAuditor.EditorTests
         TestAsset m_TestTextureReadWriteEnabled;
         TestAsset m_TextureNameStreamingMipmapDisabled;
         TestAsset m_TextureNameStreamingMipmapEnabled;
+        TestAsset m_TestTextureAnisotropicLevelBig;
+        TestAsset m_TestTextureAnisotropicLevelOne;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -97,6 +101,16 @@ namespace Unity.ProjectAuditor.EditorTests
 
             textureImporter = AssetImporter.GetAtPath(m_TextureNameStreamingMipmapEnabled.relativePath) as TextureImporter;
             textureImporter.streamingMipmaps = true;
+            textureImporter.SaveAndReimport();
+
+            m_TestTextureAnisotropicLevelBig = new TestAsset(k_TextureNameAnisotropicLevelBig + ".png", encodedPNG);
+            textureImporter = AssetImporter.GetAtPath(m_TestTextureAnisotropicLevelBig.relativePath) as TextureImporter;
+            textureImporter.anisoLevel = 2;
+            textureImporter.SaveAndReimport();
+
+            m_TestTextureAnisotropicLevelOne = new TestAsset(k_TextureNameAnisotropicLevelOne + ".png", encodedPNG);
+            textureImporter = AssetImporter.GetAtPath(m_TestTextureAnisotropicLevelOne.relativePath) as TextureImporter;
+            textureImporter.anisoLevel = 1;
             textureImporter.SaveAndReimport();
         }
 
@@ -226,5 +240,30 @@ namespace Unity.ProjectAuditor.EditorTests
 
             Assert.IsNull(textureDiagnostic);
         }
+
+        [Test]
+        public void Texture_AnisotropicLevel_IsReported()
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TestTextureAnisotropicLevelBig, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureAnisotropicLevelDescriptor));
+
+            Assert.NotNull(textureDiagnostic);
+            Assert.NotNull(textureDiagnostic.descriptor);
+            Assert.NotNull(textureDiagnostic.descriptor.fixer);
+
+            textureDiagnostic.descriptor.Fix(textureDiagnostic);
+
+            textureDiagnostic = AnalyzeAndFindAssetIssues(m_TestTextureAnisotropicLevelBig, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureAnisotropicLevelDescriptor));
+
+            Assert.Null(textureDiagnostic);
+        }
+
+        [Test]
+        public void Texture_AnisotropicLevel_IsNotReported()
+        {
+            var textureDiagnostic = AnalyzeAndFindAssetIssues(m_TestTextureAnisotropicLevelOne, IssueCategory.AssetDiagnostic).FirstOrDefault(i => i.descriptor.Equals(TextureAnalyzer.k_TextureAnisotropicLevelDescriptor));
+
+            Assert.IsNull(textureDiagnostic);
+        }
+
     }
 }


### PR DESCRIPTION
### Description

We need to create a new diagnostic to report if a texture is imported with Texture aniso level > 1.

### Screenshot

![Screenshot 2023-03-07 153554](https://user-images.githubusercontent.com/99196672/223454200-ec15e8a7-cea2-4a28-a30f-3f0df3d9bda9.png)

### Changes made

Added anisotropic texture level analyzer.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [x] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
