### PR TITLE
Fix SprBatcher fixer and add platforms to textureanisotropic level

### DIFF
--- a/Documentation~/Diagnostics.md
+++ b/Documentation~/Diagnostics.md
@@ -63,14 +63,14 @@ This is a full list of all builtin settings diagnostics:
 # Asset Diagnostics
 Builtin asset-specific diagnostics:
 
-| ID      | Title                                          | Settings  | Platforms                |
-|---------|------------------------------------------------|-----------|--------------------------|
-| PAT0000 | Texture: Mipmaps not enabled                   | Graphics  | Any                      |
-| PAT0001 | Texture: Mipmaps enabled on Sprite/UI texture  | Graphics  | Any                      |
-| PAT0002 | Texture: Read/Write enabled                    | Graphics  | Any                      |
-| PAT0003 | Texture: Streaming Mipmaps not enabled         | Graphics  | Any                      |
-| PAT0004 | Texture: Anisotropic level is more than 1      | Graphics  | Any                      |
-| PAT0005 | Texture: Solid color texture bigger than 1x1   | Graphics  | Any                      |
-| PAM0000 | Mesh: Read/Write enabled                       | Graphics  | Any                      |
-| PAM0001 | Mesh: Index Format is 32 bits                  | Graphics  | Any                      |
-| PAS0000 | Shader: Not compatible with SRP batcher        | Graphics  | Any                      |
+| ID      | Title                                          | Settings  | Platforms            |
+|---------|------------------------------------------------|-----------|----------------------|
+| PAT0000 | Texture: Mipmaps not enabled                   | Graphics  | Any                  |
+| PAT0001 | Texture: Mipmaps enabled on Sprite/UI texture  | Graphics  | Any                  |
+| PAT0002 | Texture: Read/Write enabled                    | Graphics  | Any                  |
+| PAT0003 | Texture: Streaming Mipmaps not enabled         | Graphics  | Any                  |
+| PAT0004 | Texture: Anisotropic level is more than 1      | Graphics  | Android, iOS, Switch |
+| PAT0005 | Texture: Solid color texture bigger than 1x1   | Graphics  | Any                  |
+| PAM0000 | Mesh: Read/Write enabled                       | Graphics  | Any                  |
+| PAM0001 | Mesh: Index Format is 32 bits                  | Graphics  | Any                  |
+| PAS0000 | Shader: Not compatible with SRP batcher        | Graphics  | Any                  |

--- a/Editor/Modules/TextureAnalyzer.cs
+++ b/Editor/Modules/TextureAnalyzer.cs
@@ -106,6 +106,7 @@ namespace Unity.ProjectAuditor.Editor.Modules
             "Consider setting the anisotropic level to 1."
         )
         {
+            platforms = new[] {"Android", "iOS", "Switch"},
             messageFormat = "Texture '{0}' has an anisotropic level higher than 1.",
             fixer = (issue) =>
             {

--- a/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs
+++ b/Editor/SettingsAnalysis/SrpAssetSettingsAnalyzer.cs
@@ -63,6 +63,7 @@ namespace Unity.ProjectAuditor.Editor.SettingsAnalysis
         private static void FixSrpBatcherSetting(ProjectIssue issue)
         {
 #if UNITY_2019_3_OR_NEWER
+            GraphicsSettings.useScriptableRenderPipelineBatching = true;
             int qualityLevel = issue.GetCustomPropertyInt32(0);
             if (qualityLevel == -1)
             {


### PR DESCRIPTION
Fix SprBatcher fixer and add platforms to texture anisotropic level diagnostic.

### Description

1. Set  GraphicsSettings.useScriptableRenderPipelineBatching to true, as setting it in the render pipeline is not enough.
2. Added platforms to texture anisotropic level diagnostic.


### Changes made

1. Fixed SprBatcher fixer.
2. Added platforms to texture anisotropic level diagnostic.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
