### PR TITLE
Change to ensure default settings are (re)created if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* Invalid default ProjectAuditorSettings object
+
 ## [0.10.0] - 2023-05-03
 
 ### Changed

--- a/Editor/ProjectAuditorSettingsProvider.cs
+++ b/Editor/ProjectAuditorSettingsProvider.cs
@@ -18,10 +18,18 @@ namespace Unity.ProjectAuditor.Editor
         /// </summary>
         public void Initialize()
         {
-            m_DefaultSettings = ScriptableObject.CreateInstance<ProjectAuditorSettings>();
-            m_DefaultSettings.name = "Default";
-
             RefreshAssets();
+        }
+
+        private ProjectAuditorSettings GetOrCreateDefaultSettings()
+        {
+            if (m_DefaultSettings == null)
+            {
+                m_DefaultSettings = ScriptableObject.CreateInstance<ProjectAuditorSettings>();
+                m_DefaultSettings.name = "Default";
+            }
+
+            return m_DefaultSettings;
         }
 
         /// <summary>
@@ -29,7 +37,7 @@ namespace Unity.ProjectAuditor.Editor
         /// </summary>
         internal void RefreshAssets()
         {
-            m_CurrentSettings = m_DefaultSettings;
+            m_CurrentSettings = GetOrCreateDefaultSettings();
 
             var allSettingsAssets = AssetDatabase.FindAssets("t:ProjectAuditorSettings, a:assets");
 
@@ -53,7 +61,7 @@ namespace Unity.ProjectAuditor.Editor
                 if (settings != null)
                     m_CurrentSettings = settings;
                 else
-                    SelectCurrentSettings(m_DefaultSettings);
+                    SelectCurrentSettings(GetOrCreateDefaultSettings());
             }
         }
 
@@ -65,7 +73,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             if (m_CurrentSettings == null)
             {
-                m_CurrentSettings = m_DefaultSettings;
+                m_CurrentSettings = GetOrCreateDefaultSettings();;
                 RefreshAssets();
             }
 
@@ -80,7 +88,7 @@ namespace Unity.ProjectAuditor.Editor
         {
             RefreshAssets();
 
-            yield return m_DefaultSettings;
+            yield return GetOrCreateDefaultSettings();
 
             foreach (var settingsAsset in m_SettingsAssets)
             {


### PR DESCRIPTION
### Description

Fix for invalidated default ProjectAuditorSettings:

Both Play Mode and builds invalidated the default ProjectAuditorSettings object, if the ProjectAuditorWindow was open at that time.

The added logic to recreate the default settings when returning them from the provider, if they are null.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
