### PR TITLE
Fix null ref exception on muting/unmuting group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* *NullReferenceException* on muting/unmuting a group
+
 ## [0.10.0] - 2023-05-03
 
 ### Changed

--- a/Editor/UI/Framework/AnalysisView.cs
+++ b/Editor/UI/Framework/AnalysisView.cs
@@ -425,7 +425,7 @@ namespace Unity.ProjectAuditor.Editor.UI.Framework
         public ProjectIssue[] GetSelection()
         {
             var selectedItems = m_Table.GetSelectedItems();
-            return selectedItems.Where(item => item.parent != null).Select(i => i.ProjectIssue).ToArray();
+            return selectedItems.Where(item => item.ProjectIssue != null).Select(i => i.ProjectIssue).ToArray();
         }
 
         public void SetSelection(Func<ProjectIssue, bool> predicate)


### PR DESCRIPTION
### Description

Using the Mute/Unmute button when a group is selected results in a null reference exception

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
- [ ] Docs for new/changed API's.
    - Code is annotated using Xmldoc syntax.
